### PR TITLE
Fixed bug in ConsoleUtils.ReadKeyAndAppend

### DIFF
--- a/src/THNETII.Common.Cli/ConsoleUtils.cs
+++ b/src/THNETII.Common.Cli/ConsoleUtils.cs
@@ -119,6 +119,8 @@ namespace THNETII.Common.Cli
                     builder.Clear();
                     break;
                 case ConsoleKey.Backspace:
+                    if (builder.Length < 1)
+                        break;
                     if (printAsterisk)
                         Console.Write("\b \b");
                     builder.Remove(builder.Length - 1, 1);


### PR DESCRIPTION
Fixes thrown ArgumentException when builder is empty and the key is Backspace