### PR TITLE
Add string multi-replace extension method

### DIFF
--- a/src/THNETII.Common/StringCommonExtensions.cs
+++ b/src/THNETII.Common/StringCommonExtensions.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
+using System.Text;
+using THNETII.Common.Text;
 
 namespace THNETII.Common
 {
@@ -69,6 +72,106 @@ namespace THNETII.Common
                     yield return line;
                 }
             }
+        }
+
+        /// <summary>
+        /// Performs a multi-replace operation where every occurrence of each
+        /// of the specified strings are replaced with their respective
+        /// replacement strings.
+        /// </summary>
+        /// <param name="s">The string to perform the replacements on.</param>
+        /// <param name="mappings">
+        /// The pairs of string values, where the first value in each pair
+        /// specifies the sub-string <paramref name="s"/> to search for, and the
+        /// second string specifies the value with which each occurrence should
+        /// be replaced.
+        /// </param>
+        /// <returns>
+        /// <paramref name="s"/> if <paramref name="mappings"/> is empty, or
+        /// no occurrence of the specified substrings was found; otherwise,
+        /// a new string in which all occurrences of the first value in <paramref name="mappings"/>
+        /// is replaced with the second value.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Replace"/> method is suited to replace operations
+        /// where there a fixed set of replacements to made, such as escaping,
+        /// or un-escaping operations.
+        /// </para>
+        /// <note>
+        /// The order of the replacements specified by <paramref name="mappings"/>
+        /// is relevant. Earlier replacements are preferred over later ones.
+        /// </note>
+        /// <para>
+        /// This method is optimized for linear performance and memory allocation
+        /// overhead. Thus, calling this method is more efficient than successively
+        /// calling <see cref="string.Replace(string, string)"/>.
+        /// </para>
+        /// <para>
+        /// If the resulting string has a length that is less than or equal to
+        /// the length of <paramref name="s"/>, only a single memory allocation
+        /// is required to perform all replacements.
+        /// </para>
+        /// </remarks>
+        /// <seealso cref="string.Replace(string, string)"/>
+        /// <seealso href="https://nim-lang.org/docs/strutils.html#multiReplace%2Cstring%2Cvarargs%5B%5D"/>
+        [SuppressMessage("Usage", "PC001: API not supported on all platforms")]
+        public static unsafe string Replace(this string s,
+            IEnumerable<(string oldValue, string newValue)> mappings)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+            if (mappings is null)
+                throw new ArgumentNullException(nameof(mappings));
+            var mappingList = mappings as IList<(string oldValue, string newValue)>
+                ?? mappings.ToList();
+            if (mappingList.Count < 1)
+                return s;
+            Span<char> first = stackalloc char[mappingList.Count];
+            int i, j;
+            for (i = 0, j = 0; i < mappingList.Count; i++)
+            {
+                var (oldValue, newValue) = mappingList[i];
+                if (oldValue is null)
+                    throw new ArgumentNullException(FormattableString.Invariant($"{nameof(mappings)}[{i}].{nameof(oldValue)}"));
+                if (newValue is null)
+                    throw new ArgumentNullException(FormattableString.Invariant($"{nameof(mappings)}[{i}].{nameof(newValue)}"));
+                if (oldValue.Length < 1)
+                    continue;
+                first[j] = oldValue[0];
+                j++;
+            }
+            if (j < first.Length)
+                first = first.Slice(start: 0, length: j);
+            if (first.IsEmpty)
+                return s;
+            ReadOnlySpan<char> span = s.AsSpan();
+            StringBuilder builder = new StringBuilder(s.Length);
+            int nextIdx, replacements = 0;
+            for (nextIdx = span.IndexOfAny(first); nextIdx >= 0; nextIdx = span.IndexOfAny(first))
+            {
+                builder.Append(span.Slice(start: 0, length: nextIdx));
+                span = span.Slice(nextIdx);
+                bool replaced = false;
+                foreach (var (token, replacement) in mappingList)
+                {
+                    if (token.Length < 1)
+                        continue;
+                    if (span.StartsWith(token.AsSpan()))
+                    {
+                        builder.Append(replacement);
+                        span = span.Slice(token.Length);
+                        replacements++;
+                        replaced = true;
+                        break;
+                    }
+                }
+                if (!replaced)
+                    span = span.Slice(start: 1);
+            }
+            if (replacements == 0)
+                return s;
+            return builder.ToString();
         }
     }
 }

--- a/src/THNETII.Common/THNETII.Common.csproj
+++ b/src/THNETII.Common/THNETII.Common.csproj
@@ -2,13 +2,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>7.3</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    
+
     <Description>TH-NETII .NET Common library</Description>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />

--- a/src/THNETII.Common/Text/StringBuilderExtensions.cs
+++ b/src/THNETII.Common/Text/StringBuilderExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace THNETII.Common.Text
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="StringBuilder"/> class.
+    /// </summary>
+    public static class StringBuilderExtensions
+    {
+        /// <summary>
+        /// Appends a span of Unicode characters to the specified
+        /// <see cref="StringBuilder"/> instance.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder"/> to append to. Must not be <c>null</c>.</param>
+        /// <param name="value">A read-only span of unicode characters to append.</param>
+        /// <returns>The same instance as specified by <paramref name="builder"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Enlarging the value of <paramref name="builder"/> would exceed the
+        /// <see cref="StringBuilder.MaxCapacity"/> property of <paramref name="builder"/>.
+        /// </exception>
+        /// <seealso href="https://github.com/dotnet/coreclr/pull/13163">Add StringBuilder Span-based APIs #13163</seealso>
+        public static StringBuilder Append(this StringBuilder builder,
+            ReadOnlySpan<char> value)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (value.Length > 0)
+            {
+                unsafe
+                {
+                    fixed (char* valueChars = &MemoryMarshal.GetReference(value))
+                    {
+                        builder.Append(valueChars, value.Length);
+                    }
+                }
+            }
+
+            return builder;
+        } 
+    }
+}

--- a/test/THNETII.Common.Test/Common/Test/StringCommonExtensionsTest.cs
+++ b/test/THNETII.Common.Test/Common/Test/StringCommonExtensionsTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Xunit;
@@ -53,6 +54,82 @@ namespace THNETII.Common.Test
                 .ToArray();
             var multiLine = string.Join(newline, test);
             Assert.Equal(test, multiLine.EnumerateLines());
+        }
+
+        [Fact]
+        public void MultiReplaceOnNullThrows()
+        {
+            const string nullString = null;
+            Assert.Throws<ArgumentNullException>("s", () => nullString.Replace(mappings: null));
+        }
+
+        [Fact]
+        public void MultiReplaceWithNullMappingsThrows()
+        {
+            const string test = nameof(MultiReplaceWithNullMappingsThrows);
+            Assert.Throws<ArgumentNullException>("mappings", () => test.Replace(mappings: null));
+        }
+
+        [Fact]
+        public void MultiReplaceWithNullOldValueThrows()
+        {
+            const string test = nameof(MultiReplaceWithNullOldValueThrows);
+            Assert.Throws<ArgumentNullException>(
+                FormattableString.Invariant($"mappings[{0}].oldValue"),
+                () => test.Replace(new[] { ((string)null, string.Empty) })
+                );
+        }
+
+        [Fact]
+        public void MultiReplaceWithNullNewValueThrows()
+        {
+            const string test = nameof(MultiReplaceWithNullNewValueThrows);
+            Assert.Throws<ArgumentNullException>(
+                FormattableString.Invariant($"mappings[{0}].newValue"),
+                () => test.Replace(new[] { (string.Empty, (string)null) })
+                );
+        }
+
+        [Fact]
+        public void MultiReplaceWithEmptyMappingsReturnsSame()
+        {
+            const string test = nameof(MultiReplaceWithEmptyMappingsReturnsSame);
+            Assert.Same(test, test.Replace(Enumerable.Empty<(string, string)>()));
+        }
+
+        [Fact]
+        public void MultiReplaceWithEmptyOldValueReturnsSame()
+        {
+            const string test = nameof(MultiReplaceWithEmptyOldValueReturnsSame);
+            Assert.Same(test, test.Replace(new[] { (string.Empty, string.Empty) }));
+        }
+
+        [Fact]
+        public void MultiReplaceWithNoMatchingReplacementsReturnsSame()
+        {
+            const string test = nameof(MultiReplaceWithNoMatchingReplacementsReturnsSame);
+            Assert.Same(test, test.Replace(new[] { (nameof(test), string.Empty) }));
+        }
+
+        public static IEnumerable<object[]> GetMultiReplaceParameters()
+        {
+            yield return new object[] { "abba", new[] { ("a", "b"), ("b", "a") }, "baab" };
+            yield return new object[] {
+                nameof(GetMultiReplaceParameters),
+                Enumerable.Range('a', 26).Select(v =>
+                {
+                    char lower = (char)v, upper = char.ToUpperInvariant((char)v);
+                    return (new string(lower, 1), new string(upper, 1));
+                }),
+                nameof(GetMultiReplaceParameters).ToUpperInvariant()
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetMultiReplaceParameters))]
+        public void MultiReplaceReturnsReplacedString(string oldValue, IEnumerable<(string, string)> mappings, string expected)
+        {
+            Assert.Equal(expected, oldValue.Replace(mappings), StringComparer.Ordinal);
         }
     }
 }


### PR DESCRIPTION
Adds a multi-replacement algorithm that allows to perform multiple replacements in one single pass over a string.

Algorithm adapted for C# from the Nim programming language using https://github.com/nim-lang/Nim/blob/72e15ff739cc73fbf6e3090756d3f9cb3d5af2fa/lib/pure/strutils.nim#L1596-L1624.