### PR TITLE
Update to C# 8 and enable Nullable Reference Types

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,4 +41,6 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+  <Import Condition="Exists('$(MSBuildThisFileDirectory)Directory.Nullable.props')"
+          Project="$(MSBuildThisFileDirectory)Directory.Nullable.props"/>
 </Project>

--- a/Directory.Nullable.props
+++ b/Directory.Nullable.props
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <LangVersion>8</LangVersion>
+  </PropertyGroup>
+  <ItemGroup Condition="
+             ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0') OR
+             ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1') OR
+             ('$(TargetFrameworkIdentifier)' == '.NETFramework')"
+             >
+    <PackageReference Include="Nullable" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/TH-NETII .NET Common.sln
+++ b/TH-NETII .NET Common.sln
@@ -10,8 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		AllRules.ruleset = AllRules.ruleset
 		Directory.Build.props = Directory.Build.props
-		Directory.Build.targets = Directory.Build.targets
 		Directory.Meta.props = Directory.Meta.props
+		Directory.Nullable.props = Directory.Nullable.props
 		Directory.Version.props = Directory.Version.props
 		LICENSE = LICENSE
 		NuGet.config = NuGet.config
@@ -65,7 +65,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "THNETII.TypeConverter.Xml",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "typeconverter", "typeconverter", "{55479F4D-4B67-4E47-8354-77FA6E12087E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "THNETII.CommandLine.Hosting", "src\THNETII.CommandLine.Hosting\THNETII.CommandLine.Hosting.csproj", "{1259BD34-B532-4956-8546-4690FD5EF6B6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "THNETII.CommandLine.Hosting", "src\THNETII.CommandLine.Hosting\THNETII.CommandLine.Hosting.csproj", "{1259BD34-B532-4956-8546-4690FD5EF6B6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/sample/THNETII.CommandLine.Extensions.Sample/THNETII.CommandLine.Extensions.Sample.csproj
+++ b/sample/THNETII.CommandLine.Extensions.Sample/THNETII.CommandLine.Extensions.Sample.csproj
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.2</LangVersion>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/THNETII.CommandLine.Extensions/ConsoleUtils.cs
+++ b/src/THNETII.CommandLine.Extensions/ConsoleUtils.cs
@@ -44,36 +44,34 @@ namespace THNETII.CommandLine.Extensions
         {
             if (asyncMain is null)
                 throw new ArgumentNullException(nameof(asyncMain));
-            using (var cts = new CancellationTokenSource())
+            using var cts = new CancellationTokenSource();
+            var cancelKeyPressHandler = new ConsoleCancelEventHandler((sender, e) =>
             {
-                var cancelKeyPressHandler = new ConsoleCancelEventHandler((sender, e) =>
-                {
                     // If cancellation already has been requested,
                     // do not cancel process termination signal.
                     e.Cancel = !cts.IsCancellationRequested;
 
-                    cts.Cancel(throwOnFirstException: true);
-                });
-                Console.CancelKeyPress += cancelKeyPressHandler;
+                cts.Cancel(throwOnFirstException: true);
+            });
+            Console.CancelKeyPress += cancelKeyPressHandler;
 
-                var cancelToken = cts.Token;
-                try
+            var cancelToken = cts.Token;
+            try
+            {
+                var task = asyncMain(cancelToken);
+                switch (task)
                 {
-                    var task = asyncMain(cancelToken);
-                    switch (task)
-                    {
-                        case Task<int> intTask:
-                            return await intTask.ConfigureAwait(continueOnCapturedContext: false);
-                        case Task voidTask:
-                            await voidTask.ConfigureAwait(continueOnCapturedContext: false);
-                            break;
-                    }
-                    return ProcessExitCode.ExitSuccess;
+                    case Task<int> intTask:
+                        return await intTask.ConfigureAwait(continueOnCapturedContext: false);
+                    case Task voidTask:
+                        await voidTask.ConfigureAwait(continueOnCapturedContext: false);
+                        break;
                 }
-                finally
-                {
-                    Console.CancelKeyPress -= cancelKeyPressHandler;
-                } 
+                return ProcessExitCode.ExitSuccess;
+            }
+            finally
+            {
+                Console.CancelKeyPress -= cancelKeyPressHandler;
             }
         }
 

--- a/src/THNETII.CommandLine.Extensions/ConsoleUtils.cs
+++ b/src/THNETII.CommandLine.Extensions/ConsoleUtils.cs
@@ -47,9 +47,9 @@ namespace THNETII.CommandLine.Extensions
             using var cts = new CancellationTokenSource();
             var cancelKeyPressHandler = new ConsoleCancelEventHandler((sender, e) =>
             {
-                    // If cancellation already has been requested,
-                    // do not cancel process termination signal.
-                    e.Cancel = !cts.IsCancellationRequested;
+                // If cancellation already has been requested,
+                // do not cancel process termination signal.
+                e.Cancel = !cts.IsCancellationRequested;
 
                 cts.Cancel(throwOnFirstException: true);
             });
@@ -149,7 +149,7 @@ namespace THNETII.CommandLine.Extensions
         /// <exception cref="System.IO.IOException">An I/O error occurred.</exception>
         /// <seealso cref="Console.ReadLine"/>
         /// <seealso cref="Console.ReadKey(bool)"/>
-        public static string ReadLineMasked(bool printAsterisk = true)
+        public static string? ReadLineMasked(bool printAsterisk = true)
         {
             var builder = new StringBuilder();
             bool continueReading = true;

--- a/src/THNETII.CommandLine.Extensions/THNETII.CommandLine.Extensions.csproj
+++ b/src/THNETII.CommandLine.Extensions/THNETII.CommandLine.Extensions.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>TH-NETII .NET Common extensions for the System.Console class</Description>

--- a/src/THNETII.CommandLine.Extensions/THNETII.CommandLine.Extensions.csproj
+++ b/src/THNETII.CommandLine.Extensions/THNETII.CommandLine.Extensions.csproj
@@ -2,7 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>TH-NETII .NET Common extensions for the System.Console class</Description>
   </PropertyGroup>

--- a/src/THNETII.CommandLine.Hosting/DefaultCommandLine.cs
+++ b/src/THNETII.CommandLine.Hosting/DefaultCommandLine.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 
 using System;
 using System.CommandLine.Builder;
@@ -41,7 +40,7 @@ namespace THNETII.CommandLine.Hosting
         /// root-command (or one of its sub-commands).
         /// </returns>
         public static Task<int> InvokeAsync(ICommandDefinition definition,
-            string[] args, Action<IHostBuilder> configureHost = null)
+            string[] args, Action<IHostBuilder>? configureHost = null)
         {
             if (definition is null)
                 throw new ArgumentNullException(nameof(definition));

--- a/src/THNETII.CommandLine.Hosting/THNETII.CommandLine.Hosting.csproj
+++ b/src/THNETII.CommandLine.Hosting/THNETII.CommandLine.Hosting.csproj
@@ -2,7 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>TH-NETII .NET Common extensions for the System.CommandLine.Hosting library</Description>
   </PropertyGroup>

--- a/src/THNETII.Common.BaseN/Buffers/Text/Base64UrlSafe.cs
+++ b/src/THNETII.Common.BaseN/Buffers/Text/Base64UrlSafe.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace THNETII.Common.Buffers.Text
 {
-    public static class Base64UrlSafe
+    internal static class Base64UrlSafe
     {
         private static readonly byte urlsafe62 = EncodeUtf8(Base64UrlSafeConvert.urlsafe62);
         private static readonly byte urlsafe63 = EncodeUtf8(Base64UrlSafeConvert.urlsafe63);

--- a/src/THNETII.Common.BaseN/Buffers/Text/Base64UrlSafe.cs
+++ b/src/THNETII.Common.BaseN/Buffers/Text/Base64UrlSafe.cs
@@ -72,24 +72,14 @@ namespace THNETII.Common.Buffers.Text
                 tmp = tmp.Slice(idx + 1);
             }
             var endCount = charCount % 4;
-            switch (endCount)
+            requiredPadding = endCount switch
             {
-                default:
-                case 0:
-                    requiredPadding = 0;
-                    break;
-                case 1:
-                    // Technically true, but can never happen if proper base-64
-                    // input, as there cannot be 3 padding characters in base-64.
-                    requiredPadding = 3;
-                    break;
-                case 2:
-                    requiredPadding = 2;
-                    break;
-                case 3:
-                    requiredPadding = 1;
-                    break;
-            }
+                1 => 3,// Technically true, but can never happen if proper base-64
+                       // input, as there cannot be 3 padding characters in base-64.
+                2 => 2,
+                3 => 1,
+                _ => 0,
+            };
             return charLen;
         }
     }

--- a/src/THNETII.Common.BaseN/THNETII.Common.BaseN.csproj
+++ b/src/THNETII.Common.BaseN/THNETII.Common.BaseN.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/THNETII.Common.BaseN/THNETII.Common.BaseN.csproj
+++ b/src/THNETII.Common.BaseN/THNETII.Common.BaseN.csproj
@@ -2,8 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>THNETII.Common</RootNamespace>
     <Description>

--- a/src/THNETII.Common/ArgumentExtensions.cs
+++ b/src/THNETII.Common/ArgumentExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace THNETII.Common
@@ -26,7 +27,8 @@ namespace THNETII.Common
         /// </para>
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T ThrowIfNull<T>(this T instance, string name) where T : class
+        [return: NotNull]
+        public static T ThrowIfNull<T>([NotNull] this T instance, string name) where T : class
             => instance ?? throw new ArgumentNullException(name);
 
         /// <summary>
@@ -47,7 +49,7 @@ namespace THNETII.Common
         /// <exception cref="ArgumentException"><paramref name="value"/> is empty.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string ThrowIfNullOrEmpty(this string value, string name)
+        public static string ThrowIfNullOrEmpty(this string? value, string name)
         {
             if (string.IsNullOrEmpty(value))
                 throw value is null ? new ArgumentNullException(name) : new ArgumentException("value must neither be empty, nor null.", name);
@@ -65,7 +67,7 @@ namespace THNETII.Common
         /// <exception cref="ArgumentException"><paramref name="array"/> has a length of <c>0</c> (zero).</exception>
         /// <exception cref="ArgumentNullException"><paramref name="array"/> is <see langword="null"/>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T[] ThrowIfNullOrEmpty<T>(this T[] array, string name)
+        public static T[] ThrowIfNullOrEmpty<T>(this T[]? array, string name)
         {
             switch (array)
             {
@@ -90,7 +92,7 @@ namespace THNETII.Common
         /// </remarks>
         /// <exception cref="ArgumentException"><paramref name="enumerable"/> does not contain any elements.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="enumerable"/> is <see langword="null"/>.</exception>
-        public static IEnumerable<T> ThrowIfNullOrEmpty<T>(this IEnumerable<T> enumerable, string name)
+        public static IEnumerable<T> ThrowIfNullOrEmpty<T>(this IEnumerable<T>? enumerable, string name)
         {
             switch (enumerable)
             {
@@ -148,7 +150,7 @@ namespace THNETII.Common
         /// <exception cref="ArgumentException"><paramref name="value"/> is either empty or consists only of white-space characters.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string ThrowIfNullOrWhiteSpace(this string value, string name)
+        public static string ThrowIfNullOrWhiteSpace(this string? value, string name)
         {
             if (string.IsNullOrWhiteSpace(value))
                 throw value is null ? new ArgumentNullException(nameof(name)) : new ArgumentException("value must neither be empty, nor null, nor whitespace-only.", name);

--- a/src/THNETII.Common/ArgumentExtensions.cs
+++ b/src/THNETII.Common/ArgumentExtensions.cs
@@ -100,9 +100,9 @@ namespace THNETII.Common
                     throw new ArgumentNullException(name);
                 case T[] { Length: 0 }:
                     throw new ArgumentException($"{name} is a non-null, zero-length array.", name);
-                case ICollection<T> { Count: 0 } collection:
+                case ICollection<T> c when c.Count == 0:
                     throw new ArgumentException($"{name} is a non-null, empty collection.", name);
-                case string { Length: 0 } str:
+                case string { Length: 0 }:
                     throw new ArgumentException($"{name} is a non-null, empty string.", name);
 
                 case T[] _:

--- a/src/THNETII.Common/ArgumentExtensions.cs
+++ b/src/THNETII.Common/ArgumentExtensions.cs
@@ -53,7 +53,7 @@ namespace THNETII.Common
         {
             if (string.IsNullOrEmpty(value))
                 throw value is null ? new ArgumentNullException(name) : new ArgumentException("value must neither be empty, nor null.", name);
-            return value;
+            return value!;
         }
 
         /// <summary>
@@ -69,12 +69,12 @@ namespace THNETII.Common
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T[] ThrowIfNullOrEmpty<T>(this T[]? array, string name)
         {
-            switch (array)
+            return array switch
             {
-                case null: throw new ArgumentNullException(name);
-                case var empty when empty.Length < 1: throw new ArgumentException($"{name} is a non-null, zero-length array.", name);
-                default: return array;
-            }
+                null => throw new ArgumentNullException(name),
+                { Length: 0 } => throw new ArgumentException($"{name} is a non-null, zero-length array.", name),
+                _ => array,
+            };
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace THNETII.Common
         {
             if (string.IsNullOrWhiteSpace(value))
                 throw value is null ? new ArgumentNullException(nameof(name)) : new ArgumentException("value must neither be empty, nor null, nor whitespace-only.", name);
-            return value;
+            return value!;
         }
     }
 }

--- a/src/THNETII.Common/CommonExtensions.cs
+++ b/src/THNETII.Common/CommonExtensions.cs
@@ -22,7 +22,7 @@ namespace THNETII.Common
         /// <remarks>This extension method is a convenience method that allows for functional-style chaining invocations instead of having to write an equivalent <c>if</c>-statement.</remarks>
         [return: NotNullIfNotNull("otherwise")]
         public static T NotNull<T>([MaybeNull] this T x, [MaybeNull] T otherwise)
-            where T : class => !(x is null) ? x : otherwise;
+            where T : class? => !(x is null) ? x : otherwise;
 
         /// <summary>
         /// Guards an instance against being <see langword="null"/>, creating an alternative default value if the check fails.
@@ -35,7 +35,7 @@ namespace THNETII.Common
         /// <exception cref="ArgumentNullException"><paramref name="otherwiseFactory"/> is <see langword="null"/>.</exception>
         [return: NotNull]
         public static T NotNull<T>([MaybeNull] this T x, Func<T> otherwiseFactory)
-             where T : class
+             where T : class?
         {
             if (!(x is null))
                 return x;
@@ -70,7 +70,7 @@ namespace THNETII.Common
                     throw new ArgumentNullException(nameof(otherwiseFactory));
                 return otherwiseFactory();
             }
-            return s;
+            return s!;
         }
 
         /// <summary>
@@ -263,7 +263,7 @@ namespace THNETII.Common
                     throw new ArgumentNullException(nameof(otherwiseFactory));
                 return otherwiseFactory();
             }
-            return s;
+            return s!;
         }
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace THNETII.Common
         /// <param name="x">The value to check against <see langword="null"/>.</param>
         /// <param name="value">Always returns back the value of <paramref name="x"/>.</param>
         /// <returns><see langword="true"/> if <paramref name="x"/> is not <see langword="null"/>; otherwise, <see langword="false"/>.</returns>
-        public static bool TryNotNull<T>([NotNullWhen(returnValue: true)] this T x, [NotNullWhen(returnValue: true)] out T value) where T : class
+        public static bool TryNotNull<T>([NotNullWhen(returnValue: true)] this T x, [NotNullWhen(returnValue: true)] out T value) where T : class?
         {
             value = x;
             return !(value is null);

--- a/src/THNETII.Common/CommonExtensions.cs
+++ b/src/THNETII.Common/CommonExtensions.cs
@@ -20,8 +20,9 @@ namespace THNETII.Common
         /// <param name="otherwise">The value to return in case <paramref name="x"/> is <see langword="null"/>.</param>
         /// <returns>The value of <paramref name="x"/> if <paramref name="x"/> is not <see langword="null"/>; otherwise, the value of <paramref name="otherwise"/> is returned.</returns>
         /// <remarks>This extension method is a convenience method that allows for functional-style chaining invocations instead of having to write an equivalent <c>if</c>-statement.</remarks>
+        [return: NotNullIfNotNull("x")]
         [return: NotNullIfNotNull("otherwise")]
-        public static T NotNull<T>([MaybeNull] this T x, [MaybeNull] T otherwise)
+        public static T NotNull<T>(this T x, T otherwise)
             where T : class? => !(x is null) ? x : otherwise;
 
         /// <summary>
@@ -34,7 +35,7 @@ namespace THNETII.Common
         /// <remarks>This extension method is a convenience method that allows for functional-style chaining invocations instead of having to write an equivalent <c>if</c>-statement.</remarks>
         /// <exception cref="ArgumentNullException"><paramref name="otherwiseFactory"/> is <see langword="null"/>.</exception>
         [return: NotNull]
-        public static T NotNull<T>([MaybeNull] this T x, Func<T> otherwiseFactory)
+        public static T NotNull<T>(this T x, Func<T> otherwiseFactory)
              where T : class?
         {
             if (!(x is null))
@@ -52,7 +53,8 @@ namespace THNETII.Common
         /// <returns>The value of <paramref name="s"/> if <paramref name="s"/> is neither <see langword="null"/> nor the empty string; otherwise, the value of <paramref name="otherwise"/> is returned.</returns>
         /// <remarks>This extension method is a convenience method that allows for functional-style chaining invocations instead of having to write an equivalent <c>if</c>-statement.</remarks>
         [return: NotNullIfNotNull("otherwise")]
-        public static string? NotNullOrEmpty(this string? s, string? otherwise) => string.IsNullOrEmpty(s) ? otherwise : s;
+        public static string? NotNullOrEmpty(this string? s, string? otherwise) =>
+            string.IsNullOrEmpty(s) ? otherwise : s;
 
         /// <summary>
         /// Guards a string against being <see langword="null"/> or the empty string, creating an alternative default value if the check fails.
@@ -142,28 +144,25 @@ namespace THNETII.Common
             switch (enumerable)
             {
                 case null:
+                case T[] { Length: 0 }:
+                case ICollection<T> { Count: 0 }:
+                case string { Length: 0 }:
                     return otherwise;
-                case T[] array:
-                    if (array.Length < 1)
-                        return otherwise;
+
+                case T[] _:
+                case ICollection<T> _:
+                case string _:
                     break;
-                case ICollection<T> collection:
-                    if (collection.Count < 1)
-                        return otherwise;
-                    break;
-                case string str:
-                    if (str.Length < 1)
-                        return otherwise;
-                    break;
-                case var e:
+
                 default:
+                case IEnumerable<T> e:
                     var enumerator = e.GetEnumerator();
                     if (!enumerator.MoveNext())
                     {
                         enumerator.Dispose();
                         return otherwise;
                     }
-                    IEnumerable<T> wrapAroundEnumerable()
+                    static IEnumerable<T> wrapAroundEnumerable(IEnumerator<T> enumerator)
                     {
                         using (enumerator)
                         {
@@ -173,7 +172,7 @@ namespace THNETII.Common
                             } while (enumerator.MoveNext());
                         }
                     }
-                    return wrapAroundEnumerable();
+                    return wrapAroundEnumerable(enumerator);
             }
             return enumerable;
         }
@@ -198,28 +197,25 @@ namespace THNETII.Common
             switch (enumerable)
             {
                 case null:
+                case T[] { Length: 0 }:
+                case ICollection<T> { Count: 0 }:
+                case string { Length: 0 }:
                     break;
-                case T[] array:
-                    if (array.Length < 1)
-                        break;
+
+                case T[] _:
+                case ICollection<T> _:
+                case string _:
                     return enumerable;
-                case ICollection<T> collection:
-                    if (collection.Count < 1)
-                        break;
-                    return enumerable;
-                case string str:
-                    if (str.Length < 1)
-                        break;
-                    return enumerable;
+
                 default:
-                case var e:
+                case IEnumerable<T> e:
                     var enumerator = e.GetEnumerator();
                     if (!enumerator.MoveNext())
                     {
                         enumerator.Dispose();
                         break;
                     }
-                    IEnumerable<T> wrapAroundEnumerable()
+                    static IEnumerable<T> wrapAroundEnumerable(IEnumerator<T> enumerator)
                     {
                         using (enumerator)
                         {
@@ -229,7 +225,7 @@ namespace THNETII.Common
                             } while (enumerator.MoveNext());
                         }
                     }
-                    return wrapAroundEnumerable();
+                    return wrapAroundEnumerable(enumerator);
             }
             if (otherwiseFactory is null)
                 throw new ArgumentNullException(nameof(otherwiseFactory));
@@ -245,7 +241,8 @@ namespace THNETII.Common
         /// <returns>The value of <paramref name="s"/> if <paramref name="s"/> is neither <see langword="null"/>, the empty string nor whitespace-only; otherwise, the value of <paramref name="otherwise"/> is returned.</returns>
         /// <remarks>This extension method is a convenience method that allows for functional-style chaining invocations instead of having to write an equivalent <c>if</c>-statement.</remarks>
         [return: NotNullIfNotNull("otherwise")]
-        public static string? NotNullOrWhiteSpace(this string? s, string? otherwise) => string.IsNullOrWhiteSpace(s) ? otherwise : s;
+        public static string? NotNullOrWhiteSpace(this string? s, string? otherwise) =>
+            string.IsNullOrWhiteSpace(s) ? otherwise : s;
 
         /// <summary>
         /// Guards a string against being <see langword="null"/>, empty or whitespace-only, creating an alternative default value if the check fails.
@@ -273,7 +270,9 @@ namespace THNETII.Common
         /// <param name="x">The value to check against <see langword="null"/>.</param>
         /// <param name="value">Always returns back the value of <paramref name="x"/>.</param>
         /// <returns><see langword="true"/> if <paramref name="x"/> is not <see langword="null"/>; otherwise, <see langword="false"/>.</returns>
-        public static bool TryNotNull<T>([NotNullWhen(returnValue: true)] this T x, [NotNullWhen(returnValue: true)] out T value) where T : class?
+        public static bool TryNotNull<T>(
+            [NotNullWhen(returnValue: true)] this T x,
+            [NotNullWhen(returnValue: true)] out T value) where T : class?
         {
             value = x;
             return !(value is null);
@@ -285,7 +284,9 @@ namespace THNETII.Common
         /// <param name="s">The string to check against <see langword="null"/> or the empty string.</param>
         /// <param name="value">Always returns back the value of <paramref name="s"/>.</param>
         /// <returns><see langword="true"/> if <paramref name="s"/> is neither <see langword="null"/> nor the empty string; otherwise, <see langword="false"/>.</returns>
-        public static bool TryNotNullOrEmpty([NotNullWhen(returnValue: true)] this string? s, [NotNullWhen(returnValue: true)] out string? value)
+        public static bool TryNotNullOrEmpty(
+            [NotNullWhen(returnValue: true)] this string? s,
+            [NotNullWhen(returnValue: true)] out string? value)
         {
             value = s;
             return !string.IsNullOrEmpty(value);
@@ -297,7 +298,9 @@ namespace THNETII.Common
         /// <param name="array">The array to check against <see langword="null"/> or the empty array.</param>
         /// <param name="value">Always returns back the value of <paramref name="array"/>.</param>
         /// <returns><see langword="true"/> if <paramref name="array"/> is neither <see langword="null"/> nor empty; otherwise, <see langword="false"/>.</returns>
-        public static bool TryNotNullOrEmpty<T>([NotNullWhen(returnValue: true)] this T[]? array, [NotNullWhen(returnValue: true)] out T[]? value)
+        public static bool TryNotNullOrEmpty<T>(
+            [NotNullWhen(returnValue: true)] this T[]? array,
+            [NotNullWhen(returnValue: true)] out T[]? value)
         {
             value = array;
             return !(array is null) && array.Length >= 1;
@@ -314,28 +317,34 @@ namespace THNETII.Common
         /// if the first element is availble. To prevent double evaluation of the enumerable, the created enumerator is
         /// preserved and wrapped in the new enumerable that is returned.
         /// </remarks>
-        public static bool TryNotNullOrEmpty<T>([NotNullWhen(returnValue: true)] this IEnumerable<T>? enumerable, [NotNullWhen(returnValue: true)] out IEnumerable<T>? value)
+        public static bool TryNotNullOrEmpty<T>(
+            [NotNullWhen(returnValue: true)] this IEnumerable<T>? enumerable,
+            [NotNullWhen(returnValue: true)] out IEnumerable<T>? value)
         {
             value = enumerable;
             switch (enumerable)
             {
                 case null:
+                case T[] { Length: 0 }:
+                case ICollection<T> { Count: 0 }:
+                case string { Length: 0 }:
                     return false;
-                case T[] array:
-                    return array.Length >= 1;
-                case ICollection<T> collection:
-                    return collection.Count >= 1;
-                case string str:
-                    return str.Length >= 1;
+
+                case T[] _:
+                case ICollection<T> _:
+                case string _:
+                    return true;
+
                 default:
-                case var e:
+                case IEnumerable<T> e:
                     var enumerator = e.GetEnumerator();
                     if (!enumerator.MoveNext())
                     {
                         enumerator.Dispose();
                         return false;
                     }
-                    IEnumerable<T> wrapAroundEnumerable()
+                    static IEnumerable<T> wrapAroundEnumerable(
+                        IEnumerator<T> enumerator)
                     {
                         using (enumerator)
                         {
@@ -345,7 +354,7 @@ namespace THNETII.Common
                             } while (enumerator.MoveNext());
                         }
                     }
-                    value = wrapAroundEnumerable();
+                    value = wrapAroundEnumerable(enumerator);
                     return true;
             }
         }
@@ -356,7 +365,9 @@ namespace THNETII.Common
         /// <param name="s">The string to check against <see langword="null"/>, the empty string and white-space only.</param>
         /// <param name="value">Always returns back the value of <paramref name="s"/>.</param>
         /// <returns><see langword="true"/> if <paramref name="s"/> is neither <see langword="null"/>, the empty string nor white-space only; otherwise, <see langword="false"/>.</returns>
-        public static bool TryNotNullOrWhiteSpace([NotNullWhen(returnValue: true)] this string? s, [NotNullWhen(returnValue: true)] out string? value)
+        public static bool TryNotNullOrWhiteSpace(
+            [NotNullWhen(returnValue: true)] this string? s,
+            [NotNullWhen(returnValue: true)] out string? value)
         {
             value = s;
             return !string.IsNullOrWhiteSpace(value);
@@ -371,7 +382,8 @@ namespace THNETII.Common
         /// Returns <paramref name="array"/> if it is non-<see langword="null"/>; otherwise, a zero-length <typeparamref name="T"/>-array is returned.
         /// The return value of this method is guaranteed to be non-<see langword="null"/>.
         /// </returns>
-        public static T[] ZeroLengthIfNull<T>(this T[]? array) => array ?? Array.Empty<T>();
+        public static T[] ZeroLengthIfNull<T>(this T[]? array) =>
+            array ?? Array.Empty<T>();
 
         /// <summary>
         /// Returns the specified <see cref="IEnumerable{T}"/> instance, or an empty <see cref="IEnumerable{T}"/> if the specified enumerable is <see langword="null"/>.
@@ -382,6 +394,8 @@ namespace THNETII.Common
         /// Returns <paramref name="enumerable"/> if it is non-<see langword="null"/>; otherwise, an empty <see cref="IEnumerable{T}"/> is returned.
         /// The return value of this method is guaranteed to be non-<see langword="null"/>.
         /// </returns>
-        public static IEnumerable<T> EmptyIfNull<T>(this IEnumerable<T>? enumerable) => enumerable ?? Enumerable.Empty<T>();
+        public static IEnumerable<T> EmptyIfNull<T>(
+            this IEnumerable<T>? enumerable) =>
+            enumerable ?? Enumerable.Empty<T>();
     }
 }

--- a/src/THNETII.Common/CommonExtensions.cs
+++ b/src/THNETII.Common/CommonExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace THNETII.Common
@@ -19,7 +20,8 @@ namespace THNETII.Common
         /// <param name="otherwise">The value to return in case <paramref name="x"/> is <see langword="null"/>.</param>
         /// <returns>The value of <paramref name="x"/> if <paramref name="x"/> is not <see langword="null"/>; otherwise, the value of <paramref name="otherwise"/> is returned.</returns>
         /// <remarks>This extension method is a convenience method that allows for functional-style chaining invocations instead of having to write an equivalent <c>if</c>-statement.</remarks>
-        public static T NotNull<T>(this T x, T otherwise)
+        [return: NotNullIfNotNull("otherwise")]
+        public static T NotNull<T>([MaybeNull] this T x, [MaybeNull] T otherwise)
             where T : class => !(x is null) ? x : otherwise;
 
         /// <summary>
@@ -31,7 +33,8 @@ namespace THNETII.Common
         /// <returns>The value of <paramref name="x"/> if <paramref name="x"/> is not <see langword="null"/>; otherwise, the value returned from <paramref name="otherwiseFactory"/> is returned.</returns>
         /// <remarks>This extension method is a convenience method that allows for functional-style chaining invocations instead of having to write an equivalent <c>if</c>-statement.</remarks>
         /// <exception cref="ArgumentNullException"><paramref name="otherwiseFactory"/> is <see langword="null"/>.</exception>
-        public static T NotNull<T>(this T x, Func<T> otherwiseFactory)
+        [return: NotNull]
+        public static T NotNull<T>([MaybeNull] this T x, Func<T> otherwiseFactory)
              where T : class
         {
             if (!(x is null))
@@ -48,7 +51,8 @@ namespace THNETII.Common
         /// <param name="otherwise">The value to return in case <paramref name="s"/> is <see langword="null"/> or empty.</param>
         /// <returns>The value of <paramref name="s"/> if <paramref name="s"/> is neither <see langword="null"/> nor the empty string; otherwise, the value of <paramref name="otherwise"/> is returned.</returns>
         /// <remarks>This extension method is a convenience method that allows for functional-style chaining invocations instead of having to write an equivalent <c>if</c>-statement.</remarks>
-        public static string NotNullOrEmpty(this string s, string otherwise) => string.IsNullOrEmpty(s) ? otherwise : s;
+        [return: NotNullIfNotNull("otherwise")]
+        public static string? NotNullOrEmpty(this string? s, string? otherwise) => string.IsNullOrEmpty(s) ? otherwise : s;
 
         /// <summary>
         /// Guards a string against being <see langword="null"/> or the empty string, creating an alternative default value if the check fails.
@@ -58,7 +62,7 @@ namespace THNETII.Common
         /// <returns>The value of <paramref name="s"/> if <paramref name="s"/> is neither <see langword="null"/> nor the empty string; otherwise, the value returned from <paramref name="otherwiseFactory"/> is returned.</returns>
         /// <remarks>This extension method is a convenience method that allows for functional-style chaining invocations instead of having to write an equivalent <c>if</c>-statement.</remarks>
         /// <exception cref="ArgumentNullException"><paramref name="otherwiseFactory"/> is <see langword="null"/>.</exception>
-        public static string NotNullOrEmpty(this string s, Func<string> otherwiseFactory)
+        public static string NotNullOrEmpty(this string? s, Func<string> otherwiseFactory)
         {
             if (string.IsNullOrEmpty(s))
             {
@@ -79,7 +83,8 @@ namespace THNETII.Common
         /// <paramref name="otherwise"/> if <paramref name="array"/> is <see langword="null"/> or empty;
         /// otherwise, <paramref name="array"/>.
         /// </returns>
-        public static T[] NotNullOrEmpty<T>(this T[] array, T[] otherwise)
+        [return: NotNullIfNotNull("otherwise")]
+        public static T[]? NotNullOrEmpty<T>(this T[]? array, T[]? otherwise)
         {
             switch (array)
             {
@@ -102,7 +107,7 @@ namespace THNETII.Common
         /// otherwise, <paramref name="array"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="array"/> is empty and <paramref name="otherwiseFactory"/> is <see langword="null"/>.</exception>
-        public static T[] NotNullOrEmpty<T>(this T[] array, Func<T[]> otherwiseFactory)
+        public static T[] NotNullOrEmpty<T>(this T[]? array, Func<T[]> otherwiseFactory)
         {
             switch (array)
             {
@@ -131,7 +136,8 @@ namespace THNETII.Common
         /// if the first element is availble. To prevent double evaluation of the enumerable, the created enumerator is
         /// preserved and wrapped in the new enumerable that is returned.
         /// </remarks>
-        public static IEnumerable<T> NotNullOrEmpty<T>(this IEnumerable<T> enumerable, IEnumerable<T> otherwise)
+        [return: NotNullIfNotNull("otherwise")]
+        public static IEnumerable<T>? NotNullOrEmpty<T>(this IEnumerable<T>? enumerable, IEnumerable<T>? otherwise)
         {
             switch (enumerable)
             {
@@ -187,7 +193,7 @@ namespace THNETII.Common
         /// if the first element is availble. To prevent double evaluation of the enumerable, the created enumerator is
         /// preserved and wrapped in the new enumerable that is returned.
         /// </remarks>
-        public static IEnumerable<T> NotNullOrEmpty<T>(this IEnumerable<T> enumerable, Func<IEnumerable<T>> otherwiseFactory)
+        public static IEnumerable<T> NotNullOrEmpty<T>(this IEnumerable<T>? enumerable, Func<IEnumerable<T>> otherwiseFactory)
         {
             switch (enumerable)
             {
@@ -238,7 +244,8 @@ namespace THNETII.Common
         /// <remarks>This extension method is a convenience method that allows for functional-style chaining invocations instead of having to write an equivalent <c>if</c>-statement.</remarks>
         /// <returns>The value of <paramref name="s"/> if <paramref name="s"/> is neither <see langword="null"/>, the empty string nor whitespace-only; otherwise, the value of <paramref name="otherwise"/> is returned.</returns>
         /// <remarks>This extension method is a convenience method that allows for functional-style chaining invocations instead of having to write an equivalent <c>if</c>-statement.</remarks>
-        public static string NotNullOrWhiteSpace(this string s, string otherwise) => string.IsNullOrWhiteSpace(s) ? otherwise : s;
+        [return: NotNullIfNotNull("otherwise")]
+        public static string? NotNullOrWhiteSpace(this string? s, string? otherwise) => string.IsNullOrWhiteSpace(s) ? otherwise : s;
 
         /// <summary>
         /// Guards a string against being <see langword="null"/>, empty or whitespace-only, creating an alternative default value if the check fails.
@@ -248,7 +255,7 @@ namespace THNETII.Common
         /// <returns>The value of <paramref name="s"/> if <paramref name="s"/> is neither <see langword="null"/>, the empty string nor whitespace-only; otherwise, the value returned from <paramref name="otherwiseFactory"/> is returned.</returns>
         /// <remarks>This extension method is a convenience method that allows for functional-style chaining invocations instead of having to write an equivalent <c>if</c>-statement.</remarks>
         /// <exception cref="ArgumentNullException"><paramref name="otherwiseFactory"/> is <see langword="null"/>.</exception>
-        public static string NotNullOrWhiteSpace(this string s, Func<string> otherwiseFactory)
+        public static string NotNullOrWhiteSpace(this string? s, Func<string> otherwiseFactory)
         {
             if (string.IsNullOrWhiteSpace(s))
             {
@@ -266,11 +273,11 @@ namespace THNETII.Common
         /// <param name="x">The value to check against <see langword="null"/>.</param>
         /// <param name="value">Always returns back the value of <paramref name="x"/>.</param>
         /// <returns><see langword="true"/> if <paramref name="x"/> is not <see langword="null"/>; otherwise, <see langword="false"/>.</returns>
-        public static bool TryNotNull<T>(this T x, out T value) where T : class
+        public static bool TryNotNull<T>([NotNullWhen(returnValue: true)] this T x, [NotNullWhen(returnValue: true)] out T value) where T : class
         {
             value = x;
             return !(value is null);
-        }        
+        }
 
         /// <summary>
         /// Checks whether the specified string is neither <see langword="null"/> nor empty and returns it through the out-parameter.
@@ -278,7 +285,7 @@ namespace THNETII.Common
         /// <param name="s">The string to check against <see langword="null"/> or the empty string.</param>
         /// <param name="value">Always returns back the value of <paramref name="s"/>.</param>
         /// <returns><see langword="true"/> if <paramref name="s"/> is neither <see langword="null"/> nor the empty string; otherwise, <see langword="false"/>.</returns>
-        public static bool TryNotNullOrEmpty(this string s, out string value)
+        public static bool TryNotNullOrEmpty([NotNullWhen(returnValue: true)] this string? s, [NotNullWhen(returnValue: true)] out string? value)
         {
             value = s;
             return !string.IsNullOrEmpty(value);
@@ -290,7 +297,7 @@ namespace THNETII.Common
         /// <param name="array">The array to check against <see langword="null"/> or the empty array.</param>
         /// <param name="value">Always returns back the value of <paramref name="array"/>.</param>
         /// <returns><see langword="true"/> if <paramref name="array"/> is neither <see langword="null"/> nor empty; otherwise, <see langword="false"/>.</returns>
-        public static bool TryNotNullOrEmpty<T>(this T[] array, out T[] value)
+        public static bool TryNotNullOrEmpty<T>([NotNullWhen(returnValue: true)] this T[]? array, [NotNullWhen(returnValue: true)] out T[]? value)
         {
             value = array;
             return !(array is null) && array.Length >= 1;
@@ -307,7 +314,7 @@ namespace THNETII.Common
         /// if the first element is availble. To prevent double evaluation of the enumerable, the created enumerator is
         /// preserved and wrapped in the new enumerable that is returned.
         /// </remarks>
-        public static bool TryNotNullOrEmpty<T>(this IEnumerable<T> enumerable, out IEnumerable<T> value)
+        public static bool TryNotNullOrEmpty<T>([NotNullWhen(returnValue: true)] this IEnumerable<T>? enumerable, [NotNullWhen(returnValue: true)] out IEnumerable<T>? value)
         {
             value = enumerable;
             switch (enumerable)
@@ -349,7 +356,7 @@ namespace THNETII.Common
         /// <param name="s">The string to check against <see langword="null"/>, the empty string and white-space only.</param>
         /// <param name="value">Always returns back the value of <paramref name="s"/>.</param>
         /// <returns><see langword="true"/> if <paramref name="s"/> is neither <see langword="null"/>, the empty string nor white-space only; otherwise, <see langword="false"/>.</returns>
-        public static bool TryNotNullOrWhiteSpace(this string s, out string value)
+        public static bool TryNotNullOrWhiteSpace([NotNullWhen(returnValue: true)] this string? s, [NotNullWhen(returnValue: true)] out string? value)
         {
             value = s;
             return !string.IsNullOrWhiteSpace(value);
@@ -364,7 +371,7 @@ namespace THNETII.Common
         /// Returns <paramref name="array"/> if it is non-<see langword="null"/>; otherwise, a zero-length <typeparamref name="T"/>-array is returned.
         /// The return value of this method is guaranteed to be non-<see langword="null"/>.
         /// </returns>
-        public static T[] ZeroLengthIfNull<T>(this T[] array) => array ?? Array.Empty<T>();
+        public static T[] ZeroLengthIfNull<T>(this T[]? array) => array ?? Array.Empty<T>();
 
         /// <summary>
         /// Returns the specified <see cref="IEnumerable{T}"/> instance, or an empty <see cref="IEnumerable{T}"/> if the specified enumerable is <see langword="null"/>.
@@ -375,6 +382,6 @@ namespace THNETII.Common
         /// Returns <paramref name="enumerable"/> if it is non-<see langword="null"/>; otherwise, an empty <see cref="IEnumerable{T}"/> is returned.
         /// The return value of this method is guaranteed to be non-<see langword="null"/>.
         /// </returns>
-        public static IEnumerable<T> EmptyIfNull<T>(this IEnumerable<T> enumerable) => enumerable ?? Enumerable.Empty<T>();
+        public static IEnumerable<T> EmptyIfNull<T>(this IEnumerable<T>? enumerable) => enumerable ?? Enumerable.Empty<T>();
     }
 }

--- a/src/THNETII.Common/CommonExtensions.cs
+++ b/src/THNETII.Common/CommonExtensions.cs
@@ -145,7 +145,7 @@ namespace THNETII.Common
             {
                 case null:
                 case T[] { Length: 0 }:
-                case ICollection<T> { Count: 0 }:
+                case ICollection<T> c when c.Count == 0:
                 case string { Length: 0 }:
                     return otherwise;
 
@@ -198,7 +198,7 @@ namespace THNETII.Common
             {
                 case null:
                 case T[] { Length: 0 }:
-                case ICollection<T> { Count: 0 }:
+                case ICollection<T> collection when collection.Count == 0:
                 case string { Length: 0 }:
                     break;
 
@@ -326,7 +326,7 @@ namespace THNETII.Common
             {
                 case null:
                 case T[] { Length: 0 }:
-                case ICollection<T> { Count: 0 }:
+                case ICollection<T> c when c.Count == 0:
                 case string { Length: 0 }:
                     return false;
 

--- a/src/THNETII.Common/ConversionTuple.cs
+++ b/src/THNETII.Common/ConversionTuple.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading;
-using THNETII.Common.Collections.Generic;
 
 namespace THNETII.Common
 {

--- a/src/THNETII.Common/ConversionTuple.cs
+++ b/src/THNETII.Common/ConversionTuple.cs
@@ -44,7 +44,7 @@ namespace THNETII.Common
         /// </summary>
         /// <value>The <typeparamref name="TRaw"/> value containg the value exposed by the <see cref="RawValue"/> property.</value>
         [SuppressMessage(null, "CA1051", Justification = "Member only visible internally.")]
-        internal protected TRaw rawValue;
+        internal protected TRaw rawValue = default!;
 
         /// <summary>
         /// The field storing the the tuple containing the source value and the converted value of the last performed conversion.
@@ -146,7 +146,7 @@ namespace THNETII.Common
         /// <para>If no custom <see cref="IEqualityComparer{TRaw}"/> is specified in <paramref name="rawEqualityComparer"/> or if <paramref name="rawEqualityComparer"/> is <see langword="null"/>, a reference equality check (<see cref="object.ReferenceEquals(object, object)"/> is used if <typeparamref name="TRaw"/> is a reference type. If <typeparamref name="TRaw"/> is a value type, <see cref="EqualityComparer{TRaw}.Default"/> is used as the equality comparer.</para>
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="rawConvert"/> is <see langword="null"/>.</exception>
-        public ConversionTuple(Func<TRaw, TConvert> rawConvert, IEqualityComparer<TRaw> rawEqualityComparer = null)
+        public ConversionTuple(Func<TRaw, TConvert> rawConvert, IEqualityComparer<TRaw>? rawEqualityComparer = null)
             : this(rawConvert, (!(rawEqualityComparer is null) ? rawEqualityComparer.Equals : GetEqualityCheckFunction<TRaw>())) { }
 
         /// <summary>

--- a/src/THNETII.Common/DuplexConversionTuple.cs
+++ b/src/THNETII.Common/DuplexConversionTuple.cs
@@ -57,7 +57,7 @@ namespace THNETII.Common
         /// <param name="rawReverseConvert">The function to call to convert a value from <typeparamref name="TConvert"/> to <typeparamref name="TRaw"/>. Must not be <see langword="null"/>.</param>
         /// <exception cref="ArgumentNullException">Either <paramref name="rawConvert"/> or <paramref name="rawReverseConvert"/> are <see langword="null"/>.</exception>
         public DuplexConversionTuple(Func<TRaw, TConvert> rawConvert, Func<TConvert, TRaw> rawReverseConvert)
-            : this(rawConvert, (IEqualityComparer<TRaw>)null, rawReverseConvert) { }
+            : this(rawConvert, (IEqualityComparer<TRaw>?)null, rawReverseConvert) { }
 
         /// <summary>
         /// Creates a new duplex conversion tuple with the specified conversion functions for both directions. Uses the specified equality comparer to detect changes for the raw value.
@@ -66,8 +66,8 @@ namespace THNETII.Common
         /// <param name="rawEqualityComparer">An optional equality comparer, to check whether the cached value of <see cref="ConversionTuple{TRaw, TConvert}.RawValue"/> has been changed. Specify <see langword="null"/> to use default equality checks.</param>
         /// <param name="rawReverseConvert">The function to call to convert a value from <typeparamref name="TConvert"/> to <typeparamref name="TRaw"/>. Must not be <see langword="null"/>.</param>
         /// <exception cref="ArgumentNullException">Either <paramref name="rawConvert"/> or <paramref name="rawReverseConvert"/> are <see langword="null"/>.</exception>
-        public DuplexConversionTuple(Func<TRaw, TConvert> rawConvert, IEqualityComparer<TRaw> rawEqualityComparer, Func<TConvert, TRaw> rawReverseConvert)
-            : this(rawConvert, rawEqualityComparer, rawReverseConvert, (IEqualityComparer<TConvert>)null) { }
+        public DuplexConversionTuple(Func<TRaw, TConvert> rawConvert, IEqualityComparer<TRaw>? rawEqualityComparer, Func<TConvert, TRaw> rawReverseConvert)
+            : this(rawConvert, rawEqualityComparer, rawReverseConvert, (IEqualityComparer<TConvert>?)null) { }
 
         /// <summary>
         /// Creates a new duplex conversion tuple with the specified conversion functions for both directrions. Uses the specified comparison function to detect changes for the raw value.
@@ -77,7 +77,7 @@ namespace THNETII.Common
         /// <param name="rawReverseConvert">The function to call to convert a value from <typeparamref name="TConvert"/> to <typeparamref name="TRaw"/>. Must not be <see langword="null"/>.</param>
         /// <exception cref="ArgumentNullException">Either <paramref name="rawConvert"/>, <paramref name="rawEquals"/> or <paramref name="rawReverseConvert"/> are <see langword="null"/>.</exception>
         public DuplexConversionTuple(Func<TRaw, TConvert> rawConvert, Func<TRaw, TRaw, bool> rawEquals, Func<TConvert, TRaw> rawReverseConvert)
-            : this(rawConvert, rawEquals, rawReverseConvert, (IEqualityComparer<TConvert>)null) { }
+            : this(rawConvert, rawEquals, rawReverseConvert, (IEqualityComparer<TConvert>?)null) { }
 
         /// <summary>
         /// Creates a new duplex conversion tuple with the specified conversion functions for both directions. Uses the specified equality comparer to detect changes for the converted value.
@@ -86,8 +86,8 @@ namespace THNETII.Common
         /// <param name="rawReverseConvert">The function to call to convert a value from <typeparamref name="TConvert"/> to <typeparamref name="TRaw"/>. Must not be <see langword="null"/>.</param>
         /// <param name="convertedEqualityComparer">An optional equality comparer, to check whether the cached value of <see cref="ConvertedValue"/> has been changed. Specify <see langword="null"/> to use default equality checks.</param>
         /// <exception cref="ArgumentNullException">Either <paramref name="rawConvert"/> or <paramref name="rawReverseConvert"/> are <see langword="null"/>.</exception>
-        public DuplexConversionTuple(Func<TRaw, TConvert> rawConvert, Func<TConvert, TRaw> rawReverseConvert, IEqualityComparer<TConvert> convertedEqualityComparer)
-            : this(rawConvert, (IEqualityComparer<TRaw>)null, rawReverseConvert, convertedEqualityComparer) { }
+        public DuplexConversionTuple(Func<TRaw, TConvert> rawConvert, Func<TConvert, TRaw> rawReverseConvert, IEqualityComparer<TConvert>? convertedEqualityComparer)
+            : this(rawConvert, (IEqualityComparer<TRaw>?)null, rawReverseConvert, convertedEqualityComparer) { }
 
         /// <summary>
         /// Creates a new duplex conversion tuple with the specified conversion functions for both directions. Uses the specified equality comparison function to detect changes for the converted value.
@@ -97,7 +97,7 @@ namespace THNETII.Common
         /// <param name="convertedEquals">The equality comparison function to use to check whether the cached value of <see cref="ConvertedValue"/> has been changed. Must not be <see langword="null"/>.</param>
         /// <exception cref="ArgumentNullException">Either <paramref name="rawConvert"/>, <paramref name="rawReverseConvert"/> or <paramref name="convertedEquals"/> are <see langword="null"/>.</exception>
         public DuplexConversionTuple(Func<TRaw, TConvert> rawConvert, Func<TConvert, TRaw> rawReverseConvert, Func<TConvert, TConvert, bool> convertedEquals)
-            : this(rawConvert, (IEqualityComparer<TRaw>)null, rawReverseConvert, convertedEquals) { }
+            : this(rawConvert, (IEqualityComparer<TRaw>?)null, rawReverseConvert, convertedEquals) { }
 
         /// <summary>
         /// Creates a new duplex conversion tuple with the specified conversion functions for both directions. Uses the specified equality comparers to detect changes for the raw and converted values.
@@ -107,7 +107,7 @@ namespace THNETII.Common
         /// <param name="rawReverseConvert">The function to call to convert a value from <typeparamref name="TConvert"/> to <typeparamref name="TRaw"/>. Must not be <see langword="null"/>.</param>
         /// <param name="convertedEqualityComparer">An optional equality comparer, to check whether the cached value of <see cref="ConvertedValue"/> has been changed. Specify <see langword="null"/> to use default equality checks.</param>
         /// <exception cref="ArgumentNullException">Either <paramref name="rawConvert"/> or <paramref name="rawReverseConvert"/> are <see langword="null"/>.</exception>
-        public DuplexConversionTuple(Func<TRaw, TConvert> rawConvert, IEqualityComparer<TRaw> rawEqualityComparer, Func<TConvert, TRaw> rawReverseConvert, IEqualityComparer<TConvert> convertedEqualityComparer)
+        public DuplexConversionTuple(Func<TRaw, TConvert> rawConvert, IEqualityComparer<TRaw>? rawEqualityComparer, Func<TConvert, TRaw> rawReverseConvert, IEqualityComparer<TConvert>? convertedEqualityComparer)
             : this(rawConvert, rawEqualityComparer, rawReverseConvert, !(convertedEqualityComparer is null) ? convertedEqualityComparer.Equals : GetEqualityCheckFunction<TConvert>()) { }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace THNETII.Common
         /// <param name="rawReverseConvert">The function to call to convert a value from <typeparamref name="TConvert"/> to <typeparamref name="TRaw"/>. Must not be <see langword="null"/>.</param>
         /// <param name="convertedEqualityComparer">An optional equality comparer, to check whether the cached value of <see cref="ConvertedValue"/> has been changed. Specify <see langword="null"/> to use default equality checks.</param>
         /// <exception cref="ArgumentNullException">Either <paramref name="rawConvert"/>, <paramref name="rawEquals"/> or <paramref name="rawReverseConvert"/> are <see langword="null"/>.</exception>
-        public DuplexConversionTuple(Func<TRaw, TConvert> rawConvert, Func<TRaw, TRaw, bool> rawEquals, Func<TConvert, TRaw> rawReverseConvert, IEqualityComparer<TConvert> convertedEqualityComparer)
+        public DuplexConversionTuple(Func<TRaw, TConvert> rawConvert, Func<TRaw, TRaw, bool> rawEquals, Func<TConvert, TRaw> rawReverseConvert, IEqualityComparer<TConvert>? convertedEqualityComparer)
             : this(rawConvert, rawEquals, rawReverseConvert, !(convertedEqualityComparer is null) ? convertedEqualityComparer.Equals : GetEqualityCheckFunction<TConvert>()) { }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace THNETII.Common
         /// <param name="rawReverseConvert">The function to call to convert a value from <typeparamref name="TConvert"/> to <typeparamref name="TRaw"/>. Must not be <see langword="null"/>.</param>
         /// <param name="convertedEquals">The equality comparison function to use to check whether the cached value of <see cref="ConvertedValue"/> has been changed. Must not be <see langword="null"/>.</param>
         /// <exception cref="ArgumentNullException">Either <paramref name="rawConvert"/>, <paramref name="rawReverseConvert"/> or <paramref name="convertedEquals"/> are <see langword="null"/>.</exception>
-        public DuplexConversionTuple(Func<TRaw, TConvert> rawConvert, IEqualityComparer<TRaw> rawEqualityComparer,
+        public DuplexConversionTuple(Func<TRaw, TConvert> rawConvert, IEqualityComparer<TRaw>? rawEqualityComparer,
             Func<TConvert, TRaw> rawReverseConvert, Func<TConvert, TConvert, bool> convertedEquals)
             : base(rawConvert, rawEqualityComparer)
         {

--- a/src/THNETII.Common/GlobalSuppressions.cs
+++ b/src/THNETII.Common/GlobalSuppressions.cs
@@ -7,4 +7,4 @@
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Globalization", "CA1303: Do not pass literals as localized parameters")]
-
+[assembly: SuppressMessage("Style", "IDE0056: Use index operator", Justification = "TFM pre .NET Standard 2.1")]

--- a/src/THNETII.Common/IO/CopyIOStream.cs
+++ b/src/THNETII.Common/IO/CopyIOStream.cs
@@ -105,7 +105,7 @@ namespace THNETII.Common.IO
         /// <param name="closeReadCopy">A boolean value that indicates whether to close the read-copy stream when the wrapper is closed.</param>
         /// <param name="closeWriteCopy">A boolean value that indicates whether to close the write-copy stream when the wrapper is closed.</param>
         /// <exception cref="ArgumentNullException"><paramref name="baseStream"/> is <see langword="null"/>.</exception>
-        public CopyIOStream(Stream baseStream, Stream readCopy, Stream writeCopy, bool closeBaseStream, bool closeReadCopy, bool closeWriteCopy)
+        public CopyIOStream(Stream baseStream, Stream? readCopy, Stream? writeCopy, bool closeBaseStream, bool closeReadCopy, bool closeWriteCopy)
         {
             BaseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
             CloseBaseStream = closeBaseStream;
@@ -130,7 +130,7 @@ namespace THNETII.Common.IO
         /// The <see cref="Stream"/> instance that was passed to the <see cref="CopyIOStream"/> constructor when this instance was created; 
         /// or <see langword="null"/> if the wrapper does not copy data on read operations.
         /// </value>
-        public Stream ReadCopy { get; }
+        public Stream? ReadCopy { get; }
 
         /// <summary>
         /// Gets the stream to which the wrapper writes data that is written to the origin stream.
@@ -139,7 +139,7 @@ namespace THNETII.Common.IO
         /// The <see cref="Stream"/> instance that was passed to the <see cref="CopyIOStream"/> constructor when this instance was created; 
         /// or <see langword="null"/> if the wrapper does not copy data on write operations.
         /// </value>
-        public Stream WriteCopy { get; }
+        public Stream? WriteCopy { get; }
 
         /// <summary>
         /// Gets a value that determines whether the origin stream is closed when this instance is closed.
@@ -239,7 +239,7 @@ namespace THNETII.Common.IO
             {
                 if (BaseStream.CanTimeout)
                     BaseStream.WriteTimeout = value;
-                if (ReadCopy?.CanTimeout ?? false)
+                if (WriteCopy?.CanTimeout ?? false)
                     WriteCopy.WriteTimeout = value;
             }
         }
@@ -346,7 +346,7 @@ namespace THNETII.Common.IO
 
         private int GetReadTimeout() => GetTimeout(s => s.ReadTimeout, ReadCopy);
         private int GetWriteTimeout() => GetTimeout(s => s.WriteTimeout, WriteCopy);
-        private int GetTimeout(Func<Stream, int> timeoutGetter, Stream copyStream)
+        private int GetTimeout(Func<Stream, int> timeoutGetter, Stream? copyStream)
         {
             if (BaseStream.CanTimeout)
             {

--- a/src/THNETII.Common/Maybe.cs
+++ b/src/THNETII.Common/Maybe.cs
@@ -40,22 +40,21 @@ namespace THNETII.Common
         /// </returns>
         public static int Compare<T>(Maybe<T> m1, Maybe<T> m2)
         {
-            if (m1.HasValue)
+            switch ((m1, m2))
             {
-                if (m2.HasValue)
-                {
-                    return m1.Value switch
-                    {
-                        IComparable<T> compT => compT.CompareTo(m2.Value),
-                        IComparable compAny => compAny.CompareTo(m2.Value),
-                        _ => 0,
-                    };
-                }
-                return -1;
+                case ({ HasValue: false }, { HasValue: false }):
+                    return 0;
+                case ({ HasValue: true }, { HasValue: false }):
+                    return -1;
+                case ({ HasValue: false }, { HasValue: true }):
+                    return 1;
+                case ({ HasValue: true, Value: IComparable<T> compT }, { HasValue: true }):
+                    return compT.CompareTo(m2.Value);
+                case ({ HasValue: true, Value: IComparable cmp }, { HasValue: true }):
+                    return cmp.CompareTo(m2.Value);
+                case ({ HasValue: true, }, { HasValue: true }):
+                    return 0;
             }
-            else if (m2.HasValue)
-                return 1;
-            return 0;
         }
 
         /// <summary>
@@ -102,13 +101,14 @@ namespace THNETII.Common
     public struct Maybe<T> : IEquatable<Maybe<T>>, IEquatable<T>
     {
         private static readonly string nullString = $"{null}";
-#pragma warning disable CA1000 // Do not declare static members on generic types
+
+
         /// <summary>
         /// Gets a <see cref="Maybe{T}"/> value where the value of <typeparamref name="T"/> is unset.
         /// </summary>
         /// <value>The default value of the <see cref="Maybe{T}"/> structure.</value>
+        [SuppressMessage("Design", "CA1000: Do not declare static members on generic types")]
         public static Maybe<T> NoValue { get => default; }
-#pragma warning restore CA1000 // Do not declare static members on generic types
 
         private T value;
 
@@ -468,7 +468,6 @@ namespace THNETII.Common
         public static bool operator !=(T value, Maybe<T> maybe)
             => !maybe.Equals(value);
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 #pragma warning disable CA2225 // Operator overloads have named alternates
         /// <summary>
         /// Implicityly casts a value of type <typeparamref name="T"/> to a <see cref="Maybe{T}"/> value.
@@ -492,6 +491,5 @@ namespace THNETII.Common
             { throw new InvalidCastException(null, invOpExcept); }
         }
 #pragma warning restore CA2225 // Operator overloads have named alternates
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }
 }

--- a/src/THNETII.Common/Maybe.cs
+++ b/src/THNETII.Common/Maybe.cs
@@ -44,15 +44,12 @@ namespace THNETII.Common
             {
                 if (m2.HasValue)
                 {
-                    switch (m1.Value)
+                    return m1.Value switch
                     {
-                        case IComparable<T> compT:
-                            return compT.CompareTo(m2.Value);
-                        case IComparable compAny:
-                            return compAny.CompareTo(m2.Value);
-                        default:
-                            return 0;
-                    }
+                        IComparable<T> compT => compT.CompareTo(m2.Value),
+                        IComparable compAny => compAny.CompareTo(m2.Value),
+                        _ => 0,
+                    };
                 }
                 return -1;
             }
@@ -198,15 +195,12 @@ namespace THNETII.Common
         /// </remarks>
         public override bool Equals(object obj)
         {
-            switch (obj)
+            return obj switch
             {
-                case Maybe<T> otherMaybe:
-                    return Equals(otherMaybe);
-                case T otherValue:
-                    return Equals(otherValue);
-                default:
-                    return base.Equals(obj);
-            }
+                Maybe<T> otherMaybe => Equals(otherMaybe),
+                T otherValue => Equals(otherValue),
+                _ => base.Equals(obj),
+            };
         }
 
         /// <summary>

--- a/src/THNETII.Common/Maybe.cs
+++ b/src/THNETII.Common/Maybe.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace THNETII.Common
@@ -81,7 +82,7 @@ namespace THNETII.Common
         /// or <see langword="null"/> if no <see cref="Maybe{T}"/> was specified.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="maybeType"/> is <see langword="null"/>.</exception>
-        public static Type GetUnderlyingType(Type maybeType)
+        public static Type? GetUnderlyingType(Type maybeType)
         {
             var mt = maybeType.ThrowIfNull(nameof(maybeType))
 #if NETSTANDARD1_3
@@ -165,7 +166,7 @@ namespace THNETII.Common
         /// </summary>
         public void Clear()
         {
-            value = default;
+            value = default!;
             HasValue = false;
         }
 
@@ -233,7 +234,8 @@ namespace THNETII.Common
             {
                 return (value is IEquatable<T> equatableValue)
                     ? equatableValue.Equals(otherValue)
-                    : value.Equals(otherValue);
+                    : value?.Equals(otherValue)
+                    ?? Equals(value, otherValue);
             }
             else
                 return false;
@@ -264,7 +266,8 @@ namespace THNETII.Common
             {
                 return otherMaybe.HasValue && ((value is IEquatable<T> equatableValue)
                     ? equatableValue.Equals(otherMaybe.value)
-                    : value.Equals(otherMaybe.value));
+                    : value?.Equals(otherMaybe.value)
+                    ?? Equals(value, otherMaybe.value));
             }
             else
                 return !otherMaybe.HasValue;
@@ -285,7 +288,7 @@ namespace THNETII.Common
         /// property is <see langword="true"/>; otherwise the default value of the underlying
         /// type.
         /// </returns>
-        public T GetValueOrDefault() => GetValueOrDefault(default);
+        public T GetValueOrDefault() => GetValueOrDefault(default!);
 
         /// <summary>
         /// Retrieves the assigned underlying value of the <see cref="Maybe{T}"/> structure
@@ -323,7 +326,7 @@ namespace THNETII.Common
         public override string ToString()
         {
             return HasValue
-                ? (value is object obj && obj is null) ? nullString : value.ToString()
+                ? (value is object obj && obj is null) ? nullString : value!.ToString()
                 : $"{nameof(Maybe<T>)}<{typeof(T)}>.{nameof(NoValue)}";
         }
 

--- a/src/THNETII.Common/Reflection/AssemblyAttributesAccessor.cs
+++ b/src/THNETII.Common/Reflection/AssemblyAttributesAccessor.cs
@@ -10,7 +10,7 @@ namespace THNETII.Common.Reflection
     {
         private readonly Assembly assembly;
 
-        private AssemblyCopyrightAttribute attribute_Copyright;
+        private AssemblyCopyrightAttribute? attribute_Copyright;
 
         /// <summary>
         /// Gets copyright information.
@@ -18,95 +18,95 @@ namespace THNETII.Common.Reflection
         /// <value>
         /// A string containing the copyright information, or <see langword="null"/> if none was specified when the assembly was compiled.
         /// </value>
-        public string Copyright => GetAssemblyCustomAttribute(ref attribute_Copyright)?.Copyright.NotNullOrWhiteSpace(otherwise: null);
+        public string? Copyright => GetAssemblyCustomAttribute(ref attribute_Copyright)?.Copyright.NotNullOrWhiteSpace(otherwise: null);
 
-        private AssemblyTrademarkAttribute attribute_Trademark;
+        private AssemblyTrademarkAttribute? attribute_Trademark;
 
         /// <summary>
         /// Gets trademark information.
         /// </summary>
         /// <value>A String containing trademark information, or <see langword="null"/> if none was specified when the assembly was compiled.</value>
-        public string Trademark => GetAssemblyCustomAttribute(ref attribute_Trademark)?.Trademark.NotNullOrWhiteSpace(otherwise: null);
+        public string? Trademark => GetAssemblyCustomAttribute(ref attribute_Trademark)?.Trademark.NotNullOrWhiteSpace(otherwise: null);
 
-        private AssemblyProductAttribute attribute_Product;
+        private AssemblyProductAttribute? attribute_Product;
 
         /// <summary>
         /// Gets product name information.
         /// </summary>
         /// <value>A string containing the product name, or <see langword="null"/> if none was specified when the assembly was compiled.</value>
-        public string Product => GetAssemblyCustomAttribute(ref attribute_Product)?.Product.NotNullOrWhiteSpace(otherwise: null);
+        public string? Product => GetAssemblyCustomAttribute(ref attribute_Product)?.Product.NotNullOrWhiteSpace(otherwise: null);
 
-        private AssemblyCompanyAttribute attribute_Company;
+        private AssemblyCompanyAttribute? attribute_Company;
 
         /// <summary>
         /// Gets company name information.
         /// </summary>
         /// <value>A string containing the company name, or <see langword="null"/> if none was specified when the assembly was compiled.</value>
-        public string Company => GetAssemblyCustomAttribute(ref attribute_Company)?.Company.NotNullOrWhiteSpace(otherwise: null);
+        public string? Company => GetAssemblyCustomAttribute(ref attribute_Company)?.Company.NotNullOrWhiteSpace(otherwise: null);
 
-        private AssemblyDescriptionAttribute attribute_Description;
+        private AssemblyDescriptionAttribute? attribute_Description;
 
         /// <summary>
         /// Gets assembly description information.
         /// </summary>
         /// <value>A string containing the assembly description, or <see langword="null"/> if none was specified when the assembly was compiled.</value>
-        public string Description => GetAssemblyCustomAttribute(ref attribute_Description)?.Description.NotNullOrWhiteSpace(otherwise: null);
+        public string? Description => GetAssemblyCustomAttribute(ref attribute_Description)?.Description.NotNullOrWhiteSpace(otherwise: null);
 
-        private AssemblyTitleAttribute attribute_Title;
+        private AssemblyTitleAttribute? attribute_Title;
 
         /// <summary>
         /// Gets assembly title information.
         /// </summary>
         /// <value>The assembly title, or <see langword="null"/> if none was specified when the assembly was compiled.</value>
-        public string Title => GetAssemblyCustomAttribute(ref attribute_Title)?.Title.NotNullOrWhiteSpace(otherwise: null);
+        public string? Title => GetAssemblyCustomAttribute(ref attribute_Title)?.Title.NotNullOrWhiteSpace(otherwise: null);
 
-        private AssemblyConfigurationAttribute attribute_Configuration;
+        private AssemblyConfigurationAttribute? attribute_Configuration;
 
         /// <summary>
         /// Gets assembly configuration information.
         /// </summary>
         /// <value>A string containing the assembly configuration information, or <see langword="null"/> if none was specified when the assembly was compiled.</value>
-        public string Configuration => GetAssemblyCustomAttribute(ref attribute_Configuration)?.Configuration.NotNullOrWhiteSpace(otherwise: null);
+        public string? Configuration => GetAssemblyCustomAttribute(ref attribute_Configuration)?.Configuration.NotNullOrWhiteSpace(otherwise: null);
 
-        private AssemblyDefaultAliasAttribute attribute_DefaultAlias;
+        private AssemblyDefaultAliasAttribute? attribute_DefaultAlias;
 
         /// <summary>
         /// Gets default alias information.
         /// </summary>
         /// <value>A string containing the default alias information, or <see langword="null"/> if none was specified when the assembly was compiled.</value>
-        public string DefaultAlias => GetAssemblyCustomAttribute(ref attribute_DefaultAlias)?.DefaultAlias.NotNullOrWhiteSpace(otherwise: null);
+        public string? DefaultAlias => GetAssemblyCustomAttribute(ref attribute_DefaultAlias)?.DefaultAlias.NotNullOrWhiteSpace(otherwise: null);
 
-        private AssemblyInformationalVersionAttribute attribute_InformationalVersion;
+        private AssemblyInformationalVersionAttribute? attribute_InformationalVersion;
 
         /// <summary>
         /// Gets version information.
         /// </summary>
         /// <value>A string containing the version information, or <see langword="null"/> if none was specified when the assembly was compiled.</value>
-        public string InformationalVersion => GetAssemblyCustomAttribute(ref attribute_InformationalVersion)?.InformationalVersion.NotNullOrWhiteSpace(otherwise: null);
+        public string? InformationalVersion => GetAssemblyCustomAttribute(ref attribute_InformationalVersion)?.InformationalVersion.NotNullOrWhiteSpace(otherwise: null);
 
-        private AssemblyFileVersionAttribute attribute_FileVersion;
+        private AssemblyFileVersionAttribute? attribute_FileVersion;
 
         /// <summary>
         /// Gets the Win32 file version resource name as a string.
         /// </summary>
         /// <value>A string containing the file version resource name.</value>
-        public string FileVersionString => GetAssemblyCustomAttribute(ref attribute_FileVersion)?.Version.NotNullOrWhiteSpace(otherwise: null);
+        public string? FileVersionString => GetAssemblyCustomAttribute(ref attribute_FileVersion)?.Version.NotNullOrWhiteSpace(otherwise: null);
 
         /// <summary>
         /// Gets the Win32 file version resource name.
         /// </summary>
         /// <value>The parsed <see cref="Version"/> from <see cref="FileVersionString"/> if parsing succeeds; otherwise, <see langword="null"/>.</value>
-        public Version FileVersion => Version.TryParse(FileVersionString, out Version fileVersion) ? fileVersion : null;
+        public Version? FileVersion => Version.TryParse(FileVersionString, out Version fileVersion) ? fileVersion : null;
 
-        private AssemblyCultureAttribute attribute_Culture;
+        private AssemblyCultureAttribute? attribute_Culture;
 
         /// <summary>
         /// Gets the supported culture of the attributed assembly.
         /// </summary>
         /// <value>A string containing the name of the supported culture, or <see langword="null"/> if none was specified when the assembly was compiled.</value>
-        public string Culture => GetAssemblyCustomAttribute(ref attribute_Culture)?.Culture.NotNullOrWhiteSpace(otherwise: null);
+        public string? Culture => GetAssemblyCustomAttribute(ref attribute_Culture)?.Culture.NotNullOrWhiteSpace(otherwise: null);
 
-        private AssemblyVersionAttribute attribute_Version;
+        private AssemblyVersionAttribute? attribute_Version;
 
         /// <summary>
         /// Gets the version number of the attributed assembly.
@@ -117,25 +117,25 @@ namespace THNETII.Common.Reflection
         /// <seealso cref="VersionAttributeValue"/>
         /// <seealso cref="AssemblyName"/>
         /// <seealso cref="AssemblyName.Version"/>
-        public string VersionAttributeString => GetAssemblyCustomAttribute(ref attribute_Version)?.Version.NotNullOrWhiteSpace(otherwise: null);
+        public string? VersionAttributeString => GetAssemblyCustomAttribute(ref attribute_Version)?.Version.NotNullOrWhiteSpace(otherwise: null);
 
         /// <summary>
         /// Gets the version number of the attributed assembly.
         /// <para>Applications should use the <see cref="AssemblyName.Version"/> member of the <see cref="AssemblyName"/> property instead.</para>
         /// </summary>
         /// <value>The assembly version number, or <see langword="null"/> if the assembly is not attributed with a version number, or <see langword="null"/> if the version could be parsed as a <see cref="Version"/> value.</value>
-        public Version VersionAttributeValue => Version.TryParse(VersionAttributeString, out Version version) ? version : null;
+        public Version? VersionAttributeValue => Version.TryParse(VersionAttributeString, out Version version) ? version : null;
 
-        private AssemblyKeyFileAttribute attribute_KeyFile;
+        private AssemblyKeyFileAttribute? attribute_KeyFile;
 
         /// <summary>
         /// Gets the name of the file containing the key pair used to generate a strong name
         /// for the attributed assembly.
         /// </summary>
         /// <value>A string containing the name of the file that contains the key pair, or <see langword="null"/> if none was specified when the assembly was compiled.</value>
-        public string KeyFile => GetAssemblyCustomAttribute(ref attribute_KeyFile)?.KeyFile.NotNullOrWhiteSpace(otherwise: null);
+        public string? KeyFile => GetAssemblyCustomAttribute(ref attribute_KeyFile)?.KeyFile.NotNullOrWhiteSpace(otherwise: null);
 
-        private AssemblyDelaySignAttribute attribute_DelaySign;
+        private AssemblyDelaySignAttribute? attribute_DelaySign;
 
         /// <summary>
         /// Gets a value indicating whether or not the assembly is not fully signed when created.
@@ -143,30 +143,30 @@ namespace THNETII.Common.Reflection
         /// <value><see langword="true"/> if the assembly has been built as delay-signed; otherwise, <see langword="false"/>.</value>
         public bool DelaySign => GetAssemblyCustomAttribute(ref attribute_DelaySign)?.DelaySign ?? false;
 
-        private AssemblySignatureKeyAttribute attribute_SignatureKey;
+        private AssemblySignatureKeyAttribute? attribute_SignatureKey;
 
         /// <summary>
         /// Gets the public key for the strong name used to sign the assembly.
         /// </summary>
         /// <value>The public key for the assembly, or <see langword="null"/> if the assembly was not signed when it was compiled.</value>
-        public string SignaturePublicKey => GetAssemblyCustomAttribute(ref attribute_SignatureKey)?.PublicKey.NotNullOrWhiteSpace(otherwise: null);
+        public string? SignaturePublicKey => GetAssemblyCustomAttribute(ref attribute_SignatureKey)?.PublicKey.NotNullOrWhiteSpace(otherwise: null);
 
         /// <summary>
         /// Gets the countersignature for the strong name for the assembly.
         /// </summary>
         /// <value>The countersignature for the signature key, or <see langword="null"/> if the assembly was not signed when it was compiled.</value>
-        public string CounterSignature => GetAssemblyCustomAttribute(ref attribute_SignatureKey)?.Countersignature.NotNullOrWhiteSpace(otherwise: null);
+        public string? CounterSignature => GetAssemblyCustomAttribute(ref attribute_SignatureKey)?.Countersignature.NotNullOrWhiteSpace(otherwise: null);
 
-        private AssemblyKeyNameAttribute attribute_KeyName;
+        private AssemblyKeyNameAttribute? attribute_KeyName;
 
         /// <summary>
         /// Gets the name of the container having the key pair that is used to generate a
         /// strong name for the attributed assembly.
         /// </summary>
         /// <value>A string containing the name of the container that has the relevant key pair, or <see langword="null"/> if the assembly was not signed when it was compiled.</value>
-        public string KeyName => GetAssemblyCustomAttribute(ref attribute_KeyName)?.KeyName.NotNullOrWhiteSpace(otherwise: null);
+        public string? KeyName => GetAssemblyCustomAttribute(ref attribute_KeyName)?.KeyName.NotNullOrWhiteSpace(otherwise: null);
 
-        private AssemblyName assembly_name;
+        private AssemblyName? assembly_name;
 
         /// <summary>
         /// Gets the <see cref="System.Reflection.AssemblyName"/> for the assembly.
@@ -183,16 +183,16 @@ namespace THNETII.Common.Reflection
             this.assembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
         }
 
-        private AssemblyName GetAssemblyName(ref AssemblyName assembly_name_field)
+        private AssemblyName GetAssemblyName(ref AssemblyName? assembly_name_field)
         {
-            if (assembly_name_field == null)
+            if (assembly_name_field is null)
                 assembly_name_field = assembly.GetName();
             return assembly_name_field;
         }
 
-        private TAttribute GetAssemblyCustomAttribute<TAttribute>(ref TAttribute attribute_field) where TAttribute : Attribute
+        private TAttribute GetAssemblyCustomAttribute<TAttribute>(ref TAttribute attribute_field) where TAttribute : Attribute?
         {
-            if (attribute_field == null)
+            if (attribute_field is null)
                 attribute_field = assembly.GetCustomAttribute<TAttribute>();
             return attribute_field;
         }

--- a/src/THNETII.Common/StringCommonExtensions.cs
+++ b/src/THNETII.Common/StringCommonExtensions.cs
@@ -65,12 +65,10 @@ namespace THNETII.Common
 
         private static IEnumerable<string> YieldLines(this string s)
         {
-            using (var reader = new StringReader(s))
+            using var reader = new StringReader(s);
+            for (string line = reader.ReadLine(); !(line is null); line = reader.ReadLine())
             {
-                for (string line = reader.ReadLine(); !(line is null); line = reader.ReadLine())
-                {
-                    yield return line;
-                }
+                yield return line;
             }
         }
 

--- a/src/THNETII.Common/StringEditDistanceExtensions.cs
+++ b/src/THNETII.Common/StringEditDistanceExtensions.cs
@@ -32,7 +32,7 @@ namespace THNETII.Common
             }
 
             string a = str!;
-            string b = str!;
+            string b = otherStr!;
 
             // Strip common prefix:
             // either a or b may be null, but a is the shorter string and len_a is 0 if a is null

--- a/src/THNETII.Common/StringEditDistanceExtensions.cs
+++ b/src/THNETII.Common/StringEditDistanceExtensions.cs
@@ -8,31 +8,33 @@ namespace THNETII.Common
     public static class StringEditDistanceExtensions
     {
         /// <summary>
-        /// Returns the edit distance from the current string <paramref name="a"/> to the other string <paramref name="b"/>.
+        /// Returns the edit distance from the current string <paramref name="str"/> to the other string <paramref name="otherStr"/>.
         /// <para>The edit distance between two strings, is the number of character edit operations needed in order to change one string to another.</para>
         /// </summary>
-        /// <param name="a">The original string.</param>
-        /// <param name="b">The other string to calculate the distance to.</param>
-        /// <returns>The number of characters that need to be changed, inserted or deleted in <paramref name="a"/> to produce <paramref name="b"/>.</returns>
+        /// <param name="str">The original string.</param>
+        /// <param name="otherStr">The other string to calculate the distance to.</param>
+        /// <returns>The number of characters that need to be changed, inserted or deleted in <paramref name="str"/> to produce <paramref name="otherStr"/>.</returns>
         /// <remarks>
         /// This uses the <a href="https://en.wikipedia.org/wiki/Levenshtein_distance">Levenshtein distance algorithm</a> with only a linear
         /// memory overhead.
         /// <para>This implementation is highly optimized!</para>
         /// <para>The original implementation is taken from the <c>editDistance</c> implementation found in the standard library for the Nim programming language.</para>
         /// </remarks>
-        public static int EditDistance(this string a, string b)
+        public static int EditDistance(this string? str, string? otherStr)
         {
-            int len_a = a?.Length ?? 0;
-            int len_b = b?.Length ?? 0;
+            int len_a = str?.Length ?? 0;
+            int len_b = otherStr?.Length ?? 0;
 
             // Make b the longer string
             if (len_a > len_b)
             {
-                return EditDistance(b, a);
+                return EditDistance(otherStr, str);
             }
 
+            string a = str!;
+            string b = str!;
+
             // Strip common prefix:
-#pragma warning disable CA1062 // Validate arguments of public methods
             // either a or b may be null, but a is the shorter string and len_a is 0 if a is null
             // access to a or b is safe.
             int s, s_bound = len_a;
@@ -41,7 +43,6 @@ namespace THNETII.Common
                 len_a--;
                 len_b--;
             }
-#pragma warning restore CA1062 // Validate arguments of public methods
 
             // Strip common suffix:
             while (len_a > 0 && len_b > 0 && a[s + len_a - 1] == b[s + len_b - 1])

--- a/src/THNETII.Common/THNETII.Common.csproj
+++ b/src/THNETII.Common/THNETII.Common.csproj
@@ -2,9 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <Description>TH-NETII .NET Common library</Description>

--- a/src/THNETII.DependencyInjection.Configuration/ConfigurationServiceCollectionExtensions.cs
+++ b/src/THNETII.DependencyInjection.Configuration/ConfigurationServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+
 using System;
+
 using THNETII.DependencyInjection.Nesting;
 
 namespace THNETII.DependencyInjection.Configuration
@@ -24,7 +26,7 @@ namespace THNETII.DependencyInjection.Configuration
             this IServiceCollection services, string sectionName,
             Action<INestedServiceCollection> configureServices)
         {
-            IConfiguration getConfigurationSection(IServiceProvider serviceProvider)
+            IConfiguration? getConfigurationSection(IServiceProvider serviceProvider)
             {
                 return serviceProvider
                     .GetService<RootServiceProviderAccessor>()?

--- a/src/THNETII.DependencyInjection.Configuration/THNETII.DependencyInjection.Configuration.csproj
+++ b/src/THNETII.DependencyInjection.Configuration/THNETII.DependencyInjection.Configuration.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/THNETII.DependencyInjection.Nesting/INestedServiceCollection.cs
+++ b/src/THNETII.DependencyInjection.Nesting/INestedServiceCollection.cs
@@ -13,7 +13,7 @@ namespace THNETII.DependencyInjection.Nesting
         /// inheited from the parent service collection.
         /// </summary>
         /// <value>An <see cref="IServiceCollection"/> containing the services inherited from the parent.</value>
-        IServiceCollection InheritedServices { get; }
+        IServiceCollection? InheritedServices { get; }
 
         /// <summary>
         /// Gets or sets the behaviour that controls if and how inherited

--- a/src/THNETII.DependencyInjection.Nesting/NestedScopedServicesManager.cs
+++ b/src/THNETII.DependencyInjection.Nesting/NestedScopedServicesManager.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+
 using THNETII.Common;
 
 namespace THNETII.DependencyInjection.Nesting

--- a/src/THNETII.DependencyInjection.Nesting/NestedServiceCollection.cs
+++ b/src/THNETII.DependencyInjection.Nesting/NestedServiceCollection.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+
 using THNETII.Common;
 using THNETII.Common.Collections.Generic;
 
@@ -31,7 +33,7 @@ namespace THNETII.DependencyInjection.Nesting
         public TKey Key { get; }
 
         /// <inheritdoc cref="INestedServiceCollection.InheritedServices" />
-        public IServiceCollection InheritedServices { get; }
+        public IServiceCollection? InheritedServices { get; }
 
         /// <inheritdoc cref="INestedServiceCollection.RootServicesAddBehavior" />
         public RootServicesAddBehavior RootServicesAddBehavior { get; set; } =
@@ -46,7 +48,7 @@ namespace THNETII.DependencyInjection.Nesting
         /// The parent service collection from which parent services should be inherited.
         /// </param>
         public NestedServiceCollection(TKey key,
-            IServiceCollection inheritedServices)
+            IServiceCollection? inheritedServices)
         {
             Key = key;
             InheritedServices = inheritedServices;
@@ -140,7 +142,7 @@ namespace THNETII.DependencyInjection.Nesting
 #endif
                 }
                 if (InheritedServices.Count != beforeAdd || ensureAddProxy)
-                    rootProxyDescriptors.Add(rootProxyDescriptor);
+                    rootProxyDescriptors.Add(rootProxyDescriptor); 
             }
         }
 
@@ -161,7 +163,7 @@ namespace THNETII.DependencyInjection.Nesting
             set
             {
                 if (index < InheritedCount)
-                    InheritedServices[index] = value;
+                    InheritedServices![index] = value;
                 else
                     nestedServices[index - InheritedCount] = value;
             }
@@ -215,7 +217,7 @@ namespace THNETII.DependencyInjection.Nesting
             var rootDesc = rootProxyDescriptors
                 .Where(d => d.ServiceType == nestedDesc.ServiceType)
                 .ElementAt(nestedServiceTypeIdx);
-            InheritedServices.Remove(rootDesc);
+            InheritedServices?.Remove(rootDesc);
             rootProxyDescriptors.Remove(rootDesc,
                 ReferenceEqualityComparer<ServiceDescriptor>.Default);
         }
@@ -225,7 +227,7 @@ namespace THNETII.DependencyInjection.Nesting
         {
             nestedServices.Clear();
             foreach (var proxyDesc in rootProxyDescriptors)
-                InheritedServices.Remove(proxyDesc);
+                InheritedServices?.Remove(proxyDesc);
             rootProxyDescriptors.Clear();
         }
 

--- a/src/THNETII.DependencyInjection.Nesting/NestedServiceCollectionExtensions.cs
+++ b/src/THNETII.DependencyInjection.Nesting/NestedServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@ namespace THNETII.DependencyInjection.Nesting
         private static INestedServiceCollection InternalWithRootServicesAddBehavior(
             this INestedServiceCollection services,
             RootServicesAddBehavior behavior,
-            Action<INestedServiceCollection> configureServices)
+            Action<INestedServiceCollection>? configureServices)
         {
             if (services is null)
                 throw new ArgumentNullException(nameof(services));
@@ -107,9 +107,9 @@ namespace THNETII.DependencyInjection.Nesting
         public static INestedServiceCollection<TKey> WithRootServicesAddBehavior<TKey>(
             this INestedServiceCollection<TKey> services,
             RootServicesAddBehavior behavior,
-            Action<INestedServiceCollection<TKey>> configureServices)
+            Action<INestedServiceCollection<TKey>>? configureServices)
         {
-            Action<INestedServiceCollection> internalConfigureServices;
+            Action<INestedServiceCollection>? internalConfigureServices;
             if (configureServices is null)
                 internalConfigureServices = null;
             else
@@ -135,9 +135,9 @@ namespace THNETII.DependencyInjection.Nesting
         public static INestedServiceCollection<TFamily, TKey> WithRootServicesAddBehavior<TFamily, TKey>(
             this INestedServiceCollection<TFamily, TKey> services,
             RootServicesAddBehavior behavior,
-            Action<INestedServiceCollection<TFamily, TKey>> configureServices)
+            Action<INestedServiceCollection<TFamily, TKey>>? configureServices)
         {
-            Action<INestedServiceCollection> internalConfigureServices;
+            Action<INestedServiceCollection>? internalConfigureServices;
             if (configureServices is null)
                 internalConfigureServices = null;
             else

--- a/src/THNETII.DependencyInjection.Nesting/NestedServicesServiceCollectionExtensions.cs
+++ b/src/THNETII.DependencyInjection.Nesting/NestedServicesServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+
 using System;
 
 namespace THNETII.DependencyInjection.Nesting

--- a/src/THNETII.DependencyInjection.Nesting/NestedServicesServiceProviderExtensions.cs
+++ b/src/THNETII.DependencyInjection.Nesting/NestedServicesServiceProviderExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+
 using System;
+
 using THNETII.Common;
 
 namespace THNETII.DependencyInjection.Nesting

--- a/src/THNETII.DependencyInjection.Nesting/NestedSingletonServicesManager.cs
+++ b/src/THNETII.DependencyInjection.Nesting/NestedSingletonServicesManager.cs
@@ -1,7 +1,9 @@
-﻿using System.Linq;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
+
 using System;
 using System.Collections.Generic;
+using System.Linq;
+
 using THNETII.Common;
 
 namespace THNETII.DependencyInjection.Nesting

--- a/src/THNETII.DependencyInjection.Nesting/NestingKeyComparer.cs
+++ b/src/THNETII.DependencyInjection.Nesting/NestingKeyComparer.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+
 using System;
 using System.Collections.Generic;
 

--- a/src/THNETII.DependencyInjection.Nesting/RootServicesAddBehavior.cs
+++ b/src/THNETII.DependencyInjection.Nesting/RootServicesAddBehavior.cs
@@ -36,7 +36,6 @@ namespace THNETII.DependencyInjection.Nesting
         /// extension method.
         /// </summary>
         Replace = 4,
-#if NETSTANDARD2_0
         /// <summary>
         /// Add nested services to the parent collection using the
         /// <see cref="ServiceCollectionDescriptorExtensions.Add(Microsoft.Extensions.DependencyInjection.IServiceCollection, Microsoft.Extensions.DependencyInjection.ServiceDescriptor)"/>
@@ -44,6 +43,5 @@ namespace THNETII.DependencyInjection.Nesting
         /// service type are registered.
         /// </summary>
         ReplaceAll = 5
-#endif
     }
 }

--- a/src/THNETII.DependencyInjection.Nesting/ServiceDescriptorExceptionCollection.cs
+++ b/src/THNETII.DependencyInjection.Nesting/ServiceDescriptorExceptionCollection.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/THNETII.DependencyInjection.Nesting/THNETII.DependencyInjection.Nesting.csproj
+++ b/src/THNETII.DependencyInjection.Nesting/THNETII.DependencyInjection.Nesting.csproj
@@ -2,8 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/THNETII.DependencyInjection.Nesting/THNETII.DependencyInjection.Nesting.csproj
+++ b/src/THNETII.DependencyInjection.Nesting/THNETII.DependencyInjection.Nesting.csproj
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>7.2</LangVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/THNETII.DependencyInjection/ServiceCollectionServiceProviderExtensions.cs
+++ b/src/THNETII.DependencyInjection/ServiceCollectionServiceProviderExtensions.cs
@@ -51,7 +51,7 @@ namespace THNETII.DependencyInjection
             // services for an injected Service Provider Factory.
             var defaultServiceProvider = services.BuildServiceProvider();
 
-            bool factoryPredicate(ServiceDescriptor desc)
+            static bool factoryPredicate(ServiceDescriptor desc)
             {
                 var t = desc.ServiceType
 #if NETSTANDARD1_3

--- a/src/THNETII.DependencyInjection/ServiceCollectionServiceProviderExtensions.cs
+++ b/src/THNETII.DependencyInjection/ServiceCollectionServiceProviderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+
 using System;
 using System.Linq;
 using System.Reflection;
@@ -46,7 +47,7 @@ namespace THNETII.DependencyInjection
                 throw new ArgumentNullException(nameof(services));
             }
 
-            IServiceProvider serviceProvider = null;
+            IServiceProvider? serviceProvider = null;
             // Create a default ServiceProvider to use to dependency inject
             // services for an injected Service Provider Factory.
             var defaultServiceProvider = services.BuildServiceProvider();

--- a/src/THNETII.DependencyInjection/THNETII.DependencyInjection.csproj
+++ b/src/THNETII.DependencyInjection/THNETII.DependencyInjection.csproj
@@ -2,8 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/THNETII.Diagnostics.DiagnosticSourceExtensions/DiagnosticSourceExtensions.cs
+++ b/src/THNETII.Diagnostics.DiagnosticSourceExtensions/DiagnosticSourceExtensions.cs
@@ -26,7 +26,7 @@ namespace THNETII.Diagnostics.DiagnosticSourceExtensions
         /// This extension method serves as a convenience method to condense the otherwise recommended <c>if</c>-block for logging to a <see cref="DiagnosticSource"/> instance.
         /// <para>If <paramref name="diagnosticSource"/> is <see langword="null"/>, <see langword="null"/> is returned.</para>
         /// </remarks>
-        public static DiagnosticSourceWriter? IfEnabled(this DiagnosticSource diagnosticSource, string name)
+        public static DiagnosticSourceWriter? IfEnabled(this DiagnosticSource? diagnosticSource, string name)
         {
             if (diagnosticSource?.IsEnabled(name) ?? false == false)
                 return null;
@@ -53,7 +53,7 @@ namespace THNETII.Diagnostics.DiagnosticSourceExtensions
         /// <para>If <paramref name="diagnosticSource"/> is <see langword="null"/>, <see langword="null"/> is returned.</para>
         /// </remarks>
         /// <seealso cref="IfEnabled(DiagnosticSource, string)"/>
-        public static DiagnosticSourceWriter? IfEnabled(this DiagnosticSource diagnosticSource, string name, object arg1, object arg2 = null)
+        public static DiagnosticSourceWriter? IfEnabled(this DiagnosticSource? diagnosticSource, string name, object arg1, object? arg2 = null)
         {
             if (diagnosticSource?.IsEnabled(name, arg1, arg2) ?? false == false)
                 return null;

--- a/src/THNETII.Diagnostics.DiagnosticSourceExtensions/DiagnosticSourceWriter.cs
+++ b/src/THNETII.Diagnostics.DiagnosticSourceExtensions/DiagnosticSourceWriter.cs
@@ -48,14 +48,11 @@ namespace THNETII.Diagnostics.DiagnosticSourceExtensions
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            switch (obj)
+            return obj switch
             {
-                case DiagnosticSourceWriter other:
-                    return Equals(other);
-                default:
-                case null:
-                    return false;
-            }
+                DiagnosticSourceWriter other => Equals(other),
+                _ => false,
+            };
         }
 
         /// <inheritdoc cref="object.GetHashCode"/>

--- a/src/THNETII.Diagnostics.DiagnosticSourceExtensions/DiagnosticSourceWriter.cs
+++ b/src/THNETII.Diagnostics.DiagnosticSourceExtensions/DiagnosticSourceWriter.cs
@@ -10,7 +10,7 @@ namespace THNETII.Diagnostics.DiagnosticSourceExtensions
     /// </summary>
     public readonly struct DiagnosticSourceWriter : IEquatable<DiagnosticSourceWriter>
     {
-        private readonly DiagnosticSource diagnosticSource;
+        private readonly DiagnosticSource? diagnosticSource;
 
         /// <summary>
         /// Gets the name of the event being written.
@@ -24,7 +24,7 @@ namespace THNETII.Diagnostics.DiagnosticSourceExtensions
         /// </summary>
         /// <param name="diagnosticSource">The <see cref="DiagnosticSource"/> to write to. Can be <see langword="null"/>.</param>
         /// <param name="name">The name of the event being written.</param>
-        public DiagnosticSourceWriter(DiagnosticSource diagnosticSource, string name)
+        public DiagnosticSourceWriter(DiagnosticSource? diagnosticSource, string name)
         {
             this.diagnosticSource = diagnosticSource;
             Name = name;

--- a/src/THNETII.Diagnostics.DiagnosticSourceExtensions/THNETII.Diagnostics.DiagnosticSourceExtensions.csproj
+++ b/src/THNETII.Diagnostics.DiagnosticSourceExtensions/THNETII.Diagnostics.DiagnosticSourceExtensions.csproj
@@ -2,7 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/THNETII.Diagnostics.DiagnosticSourceExtensions/THNETII.Diagnostics.DiagnosticSourceExtensions.csproj
+++ b/src/THNETII.Diagnostics.DiagnosticSourceExtensions/THNETII.Diagnostics.DiagnosticSourceExtensions.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/THNETII.Networking.Http/HttpContentExtensions.cs
+++ b/src/THNETII.Networking.Http/HttpContentExtensions.cs
@@ -28,7 +28,7 @@ namespace THNETII.Networking.Http
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="httpContent"/> is <see langword="null"/>.</exception>
         /// <seealso cref="HttpContentHeaders.ContentType"/>
-        public static bool IsText(this HttpContent httpContent, bool trueIfNoContentType = true)
+        public static bool IsText(this HttpContent? httpContent, bool trueIfNoContentType = true)
         {
             if (httpContent is null)
                 return false;
@@ -50,7 +50,7 @@ namespace THNETII.Networking.Http
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="httpContent"/> is <see langword="null"/>.</exception>
         /// <seealso cref="HttpContentHeaders.ContentType"/>
-        public static bool IsHtml(this HttpContent httpContent, bool trueIfNoContentType = true)
+        public static bool IsHtml(this HttpContent? httpContent, bool trueIfNoContentType = true)
         {
             if (httpContent is null)
                 return false;
@@ -72,7 +72,7 @@ namespace THNETII.Networking.Http
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="httpContent"/> is <see langword="null"/>.</exception>
         /// <seealso cref="HttpContentHeaders.ContentType"/>
-        public static bool IsXml(this HttpContent httpContent, bool trueIfNoContentType = true)
+        public static bool IsXml(this HttpContent? httpContent, bool trueIfNoContentType = true)
         {
             if (httpContent is null)
                 return false;
@@ -94,7 +94,7 @@ namespace THNETII.Networking.Http
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="httpContent"/> is <see langword="null"/>.</exception>
         /// <seealso cref="HttpContentHeaders.ContentType"/>
-        public static bool IsJson(this HttpContent httpContent, bool trueIfNoContentType = true)
+        public static bool IsJson(this HttpContent? httpContent, bool trueIfNoContentType = true)
         {
             if (httpContent is null)
                 return false;
@@ -119,21 +119,21 @@ namespace THNETII.Networking.Http
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="httpContent"/> is <see langword="null"/>.</exception>
         /// <seealso cref="HttpContent.ReadAsStreamAsync"/>
-        public static async Task<StreamReader> ReadAsStreamReaderAsync(this HttpContent httpContent, Encoding defaultEncoding = null)
+        public static async Task<StreamReader> ReadAsStreamReaderAsync(this HttpContent httpContent, Encoding? defaultEncoding = null)
         {
             if (httpContent is null)
                 throw new ArgumentNullException(nameof(httpContent));
 
             var readStreamTask = httpContent.ReadAsStreamAsync();
-            Encoding encoding = GetContentCharsetEncoding(httpContent, defaultEncoding);
+            Encoding? encoding = GetContentCharsetEncoding(httpContent, defaultEncoding);
             var stream = await readStreamTask.ConfigureAwait(continueOnCapturedContext: false);
             return encoding is null ? new StreamReader(stream) : new StreamReader(stream, encoding);
         }
 
-        private static Encoding GetContentCharsetEncoding(HttpContent httpContent, Encoding defaultEncoding = null)
+        private static Encoding? GetContentCharsetEncoding(HttpContent httpContent, Encoding? defaultEncoding = null)
         {
             var charset = httpContent.Headers.ContentType?.CharSet;
-            Encoding encoding = defaultEncoding;
+            Encoding? encoding = defaultEncoding;
             if (!string.IsNullOrWhiteSpace(charset))
             {
                 try

--- a/src/THNETII.Networking.Http/HttpUrlHelper.cs
+++ b/src/THNETII.Networking.Http/HttpUrlHelper.cs
@@ -6,11 +6,31 @@ using THNETII.Common;
 
 namespace THNETII.Networking.Http
 {
+    /// <summary>
+    /// Helper class that provides useful helper methods in constructing URLs
+    /// and query strings.
+    /// </summary>
     public static class HttpUrlHelper
     {
         private static StringBuilder? queryBuilder;
 
-        public static string ToQueryString(IEnumerable<KeyValuePair<string, string>>? queryParams)
+        /// <summary>
+        /// Constructs a query string using the specified enumerable of
+        /// string-typed key-value-pairs. Each value is URI-escaped as URI data.
+        /// </summary>
+        /// <param name="queryParams">
+        /// A sequence of string-typed key-value-pairs. Multiple equal key
+        /// values are allowed. <see langword="null"/> values are allowed.
+        /// The sequence can be <see langword="null"/>.
+        /// </param>
+        /// <returns>
+        /// A non-<see langword="null"/> <see cref="string"/> starting with the
+        /// leading <c>'?'</c>. If <paramref name="queryParams"/> contains any
+        /// pairs, the pair is added to the query string. Pairs where the key is
+        /// either <see langword="null"/>, empty or contains only whitespace are
+        /// skipped regardless of the value of the pair.
+        /// </returns>
+        public static string ToQueryString(IEnumerable<KeyValuePair<string, string?>>? queryParams)
         {
             if (queryParams is null)
                 return "?";

--- a/src/THNETII.Networking.Http/HttpUrlHelper.cs
+++ b/src/THNETII.Networking.Http/HttpUrlHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text;
 
 using THNETII.Common;
@@ -9,9 +8,9 @@ namespace THNETII.Networking.Http
 {
     public static class HttpUrlHelper
     {
-        private static StringBuilder queryBuilder;
+        private static StringBuilder? queryBuilder;
 
-        public static string ToQueryString(IEnumerable<KeyValuePair<string, string>> queryParams)
+        public static string ToQueryString(IEnumerable<KeyValuePair<string, string>>? queryParams)
         {
             if (queryParams is null)
                 return "?";
@@ -25,7 +24,7 @@ namespace THNETII.Networking.Http
             bool first = true;
             foreach (var queryPair in queryParams)
             {
-                if (queryPair.Key.TryNotNullOrWhiteSpace(out string key))
+                if (queryPair.Key.TryNotNullOrWhiteSpace(out var key))
                 {
                     if (!first)
                         queryBuilder.Append('&');

--- a/src/THNETII.Networking.Http/MediaTypeHeaderValueExtensions.cs
+++ b/src/THNETII.Networking.Http/MediaTypeHeaderValueExtensions.cs
@@ -22,9 +22,9 @@ namespace THNETII.Networking.Http
         /// </returns>
         /// <remarks>String comparison is done using the <see cref="StringComparison.OrdinalIgnoreCase"/> comparison option.</remarks>
         /// <seealso cref="StringCommonExtensions.Contains(string, string, StringComparison)"/>
-        public static bool ContainsMediaType(this MediaTypeHeaderValue header, string mediaType, bool trueIfNoMediaType = true)
+        public static bool ContainsMediaType(this MediaTypeHeaderValue? header, string mediaType, bool trueIfNoMediaType = true)
         {
-            if (!(header?.MediaType).TryNotNullOrWhiteSpace(out string contentMediaType))
+            if (!(header?.MediaType).TryNotNullOrWhiteSpace(out var contentMediaType))
                 return trueIfNoMediaType;
             return contentMediaType.Contains(mediaType, StringComparison.OrdinalIgnoreCase);
         }
@@ -39,7 +39,7 @@ namespace THNETII.Networking.Http
         /// <paramref name="trueIfNoMediaType"/> if <paramref name="header"/> is <see langword="null"/> or the <see cref="MediaTypeHeaderValue.MediaType"/> property of <paramref name="header"/> is <see langword="null"/> or only contains white-space characters.<br/>
         /// Otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool IsText(this MediaTypeHeaderValue header, bool trueIfNoMediaType = true)
+        public static bool IsText(this MediaTypeHeaderValue? header, bool trueIfNoMediaType = true)
             => ContainsMediaType(header, HttpWellKnownMediaType.Text, trueIfNoMediaType);
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace THNETII.Networking.Http
         /// <paramref name="trueIfNoMediaType"/> if <paramref name="header"/> is <see langword="null"/> or the <see cref="MediaTypeHeaderValue.MediaType"/> property of <paramref name="header"/> is <see langword="null"/> or only contains white-space characters.<br/>
         /// Otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool IsHtml(this MediaTypeHeaderValue header, bool trueIfNoMediaType = true)
+        public static bool IsHtml(this MediaTypeHeaderValue? header, bool trueIfNoMediaType = true)
             => ContainsMediaType(header, HttpWellKnownMediaType.Html, trueIfNoMediaType);
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace THNETII.Networking.Http
         /// <paramref name="trueIfNoMediaType"/> if <paramref name="header"/> is <see langword="null"/> or the <see cref="MediaTypeHeaderValue.MediaType"/> property of <paramref name="header"/> is <see langword="null"/> or only contains white-space characters.<br/>
         /// Otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool IsJson(this MediaTypeHeaderValue header, bool trueIfNoMediaType = true)
+        public static bool IsJson(this MediaTypeHeaderValue? header, bool trueIfNoMediaType = true)
             => ContainsMediaType(header, HttpWellKnownMediaType.Json, trueIfNoMediaType);
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace THNETII.Networking.Http
         /// <paramref name="trueIfNoMediaType"/> if <paramref name="header"/> is <see langword="null"/> or the <see cref="MediaTypeHeaderValue.MediaType"/> property of <paramref name="header"/> is <see langword="null"/> or only contains white-space characters.<br/>
         /// Otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool IsXml(this MediaTypeHeaderValue header, bool trueIfNoMediaType = true)
+        public static bool IsXml(this MediaTypeHeaderValue? header, bool trueIfNoMediaType = true)
             => ContainsMediaType(header, HttpWellKnownMediaType.Xml, trueIfNoMediaType);
     }
 }

--- a/src/THNETII.Networking.Http/THNETII.Networking.Http.csproj
+++ b/src/THNETII.Networking.Http/THNETII.Networking.Http.csproj
@@ -2,8 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <Description>TH-NETII .NET Common values and methods for HTTP operations</Description>

--- a/src/THNETII.Networking.Http/THNETII.Networking.Http.csproj
+++ b/src/THNETII.Networking.Http/THNETII.Networking.Http.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/THNETII.TypeConverter.Json/THNETII.TypeConverter.Json.csproj
+++ b/src/THNETII.TypeConverter.Json/THNETII.TypeConverter.Json.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>TH-NETII .NET Common library extension for type conversion for types annotated with Json.NET attributes</Description>

--- a/src/THNETII.TypeConverter.Json/THNETII.TypeConverter.Json.csproj
+++ b/src/THNETII.TypeConverter.Json/THNETII.TypeConverter.Json.csproj
@@ -2,7 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>TH-NETII .NET Common library extension for type conversion for types annotated with Json.NET attributes</Description>
   </PropertyGroup>

--- a/src/THNETII.TypeConverter.Serialization/EnumMemberStringConverter.cs
+++ b/src/THNETII.TypeConverter.Serialization/EnumMemberStringConverter.cs
@@ -76,7 +76,7 @@ namespace THNETII.TypeConverter.Serialization
         {
             if (!(s is null) && EnumValues<T>.StringToValue.TryGetValue(s, out T value))
                 return value;
-            return EnumStringConverter.Parse<T>(s);
+            return EnumStringConverter.Parse<T>(s!);
         }
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace THNETII.TypeConverter.Serialization
         {
             if (!(s is null) && EnumValues<T>.StringToValue.TryGetValue(s, out value))
                 return true;
-            return EnumStringConverter.TryParse(s, out value);
+            return EnumStringConverter.TryParse(s!, out value);
         }
 
         /// <summary>

--- a/src/THNETII.TypeConverter.Serialization/THNETII.TypeConverter.Serialization.csproj
+++ b/src/THNETII.TypeConverter.Serialization/THNETII.TypeConverter.Serialization.csproj
@@ -2,7 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>TH-NETII .NET Common library extension for type conversion for types annotated with attributes from the System.Runtime.Serialization namespace</Description>
   </PropertyGroup>

--- a/src/THNETII.TypeConverter.Serialization/THNETII.TypeConverter.Serialization.csproj
+++ b/src/THNETII.TypeConverter.Serialization/THNETII.TypeConverter.Serialization.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>TH-NETII .NET Common library extension for type conversion for types annotated with attributes from the System.Runtime.Serialization namespace</Description>

--- a/src/THNETII.TypeConverter.Xml/THNETII.TypeConverter.Xml.csproj
+++ b/src/THNETII.TypeConverter.Xml/THNETII.TypeConverter.Xml.csproj
@@ -2,7 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>TH-NETII .NET Common library extension for type conversion for types annotated with attributes from the System.Xml namespace</Description>
   </PropertyGroup>

--- a/src/THNETII.TypeConverter.Xml/THNETII.TypeConverter.Xml.csproj
+++ b/src/THNETII.TypeConverter.Xml/THNETII.TypeConverter.Xml.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
     <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>TH-NETII .NET Common library extension for type conversion for types annotated with attributes from the System.Xml namespace</Description>

--- a/src/THNETII.TypeConverter.Xml/XmlEnumStringConverter.cs
+++ b/src/THNETII.TypeConverter.Xml/XmlEnumStringConverter.cs
@@ -81,7 +81,7 @@ namespace THNETII.TypeConverter.Xml
         {
             if (!(s is null) && EnumValues<T>.StringToValue.TryGetValue(s, out T value))
                 return value;
-            return EnumStringConverter.Parse<T>(s);
+            return EnumStringConverter.Parse<T>(s!);
         }
 
         /// <summary>
@@ -211,7 +211,7 @@ namespace THNETII.TypeConverter.Xml
         {
             if (!(s is null) && EnumValues<T>.StringToValue.TryGetValue(s, out value))
                 return true;
-            return EnumStringConverter.TryParse(s, out value);
+            return EnumStringConverter.TryParse(s!, out value);
         }
 
         /// <summary>

--- a/src/THNETII.TypeConverter/Base64UrlEncoder.cs
+++ b/src/THNETII.TypeConverter/Base64UrlEncoder.cs
@@ -25,7 +25,7 @@ namespace THNETII.TypeConverter
         /// </summary>
         /// <param name="base64String">A regular Base64 encoded data string. Can be <see langword="null"/>.</param>
         /// <returns>A URL-safe Base64 encoded representation of the specified input data; or <see langword="null"/> if the specified input parameter is <see langword="null"/>.</returns>
-        public static string ToBase64UrlString(string base64String) =>
+        public static string? ToBase64UrlString(string? base64String) =>
             string.IsNullOrWhiteSpace(base64String) ? null : ToBase64UrlString(new StringBuilder(base64String));
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace THNETII.TypeConverter
         /// </summary>
         /// <param name="data">An array of bytes that contains the data to encode. Can be <see langword="null"/>.</param>
         /// <returns>A URL-safe Base64 encoded representation of the specified input data; or <see langword="null"/> if the specified input parameter is <see langword="null"/>.</returns>
-        public static string ToBase64UrlString(byte[] data) =>
+        public static string? ToBase64UrlString(byte[]? data) =>
             data is null ? null : ToBase64UrlString(new StringBuilder(Convert.ToBase64String(data)));
 
         /// <exception cref="FormatException">The URL-safe Base64 encoded string has an invalid length.</exception>
@@ -58,7 +58,7 @@ namespace THNETII.TypeConverter
         /// <param name="base64UrlString">The URL-safe Base64 data string. Can be <see langword="null"/>.</param>
         /// <returns>An array of bytes containg the data that is represented by <paramref name="base64UrlString"/>. <see langword="null"/> if <paramref name="base64UrlString"/> is <see langword="null"/>.</returns>
         /// <exception cref="FormatException"><paramref name="base64UrlString"/> is not a valid URL-safe Base64 encoded data string.</exception>
-        public static byte[] FromBase64UrlString(string base64UrlString)
+        public static byte[]? FromBase64UrlString(string? base64UrlString)
         {
             if (string.IsNullOrWhiteSpace(base64UrlString))
                 return null;
@@ -72,7 +72,7 @@ namespace THNETII.TypeConverter
         /// <param name="base64UrlString">The URL-safe Base64 data string. Can be <see langword="null"/>.</param>
         /// <returns>A regular Base64 data string that represents the exact same that as <paramref name="base64UrlString"/>. <see langword="null"/> if <paramref name="base64UrlString"/> is <see langword="null"/>.</returns>
         /// <exception cref="FormatException"><paramref name="base64UrlString"/> is not a valid URL-safe Base64 encoded data string. The length of the string is invalid.</exception>
-        public static string ToRegularBase64String(string base64UrlString) =>
+        public static string? ToRegularBase64String(string? base64UrlString) =>
             string.IsNullOrWhiteSpace(base64UrlString) ? null : FromBase64UrlString(new StringBuilder(base64UrlString));
     }
 }

--- a/src/THNETII.TypeConverter/BooleanStringConverter.cs
+++ b/src/THNETII.TypeConverter/BooleanStringConverter.cs
@@ -58,7 +58,7 @@ namespace THNETII.TypeConverter
         /// class for more information on the conversion rules.
         /// </remarks>
         /// <exception cref="FormatException"><paramref name="s"/> cannot be converted to a <see cref="bool"/> value.</exception>
-        public static bool Parse(string s)
+        public static bool Parse(string? s)
         {
             if (bool.TryParse(s, out bool v))
                 return v;
@@ -143,7 +143,7 @@ namespace THNETII.TypeConverter
         public static bool? ParseOrNull(string s)
             => TryParse(s, out bool value) ? (bool?)value : null;
 
-        private static bool TryParseAlternative(string s, out bool alternateResult)
+        private static bool TryParseAlternative(string? s, out bool alternateResult)
         {
             if (s is null)
             {

--- a/src/THNETII.TypeConverter/EnumStringConverter.cs
+++ b/src/THNETII.TypeConverter/EnumStringConverter.cs
@@ -86,7 +86,7 @@ namespace THNETII.TypeConverter
                     return (EnumTryParseFunc<T>)miNumeric.Invoke(null, new[] { numberConverter });
                 }
 
-                return null;
+                return null!;
             }
 
             static EnumTryParseFunc<TEnum> InitializeNumericTryParseFromUnderlyingType<TNumeric, TEnum>(NumberStringConverter<TNumeric> numberStringConverter)

--- a/src/THNETII.TypeConverter/NumberStringConverter.cs
+++ b/src/THNETII.TypeConverter/NumberStringConverter.cs
@@ -40,7 +40,7 @@ namespace THNETII.TypeConverter
     {
         private readonly NumberStylesParseFunc<T> parse;
         private readonly NumberStylesTryParseFunc<T> tryParse;
-        private readonly IFormatProvider formatProvider;
+        private readonly IFormatProvider? formatProvider;
 
         /// <summary>
         /// Initializes a new <see cref="NumberStringConverter{T}"/> using the
@@ -60,7 +60,7 @@ namespace THNETII.TypeConverter
         /// <seealso cref="int.Parse(string, NumberStyles, IFormatProvider)"/>
         /// <seealso cref="int.TryParse(string, NumberStyles, IFormatProvider, out int)"/>
         public NumberStringConverter(NumberStylesParseFunc<T> parse,
-            NumberStylesTryParseFunc<T> tryParse, IFormatProvider formatProvider = default)
+            NumberStylesTryParseFunc<T> tryParse, IFormatProvider? formatProvider = default)
         {
             this.parse = parse ?? throw new ArgumentNullException(nameof(parse));
             this.tryParse = tryParse ?? throw new ArgumentNullException(nameof(tryParse));

--- a/src/THNETII.TypeConverter/NumberStylesParseFunc.cs
+++ b/src/THNETII.TypeConverter/NumberStylesParseFunc.cs
@@ -19,5 +19,5 @@ namespace THNETII.TypeConverter
     /// <exception cref="FormatException"><paramref name="s"/> is not in a format compliant with <paramref name="style"/>.</exception>
     /// <exception cref="OverflowException">The number represented by <paramref name="s"/> cannot losslessly fit into a value of type <typeparamref name="T"/>.</exception>
     public delegate T NumberStylesParseFunc<T>(string s, NumberStyles style,
-        IFormatProvider formatProvider);
+        IFormatProvider? formatProvider);
 }

--- a/src/THNETII.TypeConverter/NumberStylesTryParseFunc.cs
+++ b/src/THNETII.TypeConverter/NumberStylesTryParseFunc.cs
@@ -25,5 +25,5 @@ namespace THNETII.TypeConverter
     /// <returns><see langword="true"/> is <paramref name="s"/> was converted successfully; otherwise, <see langword="false"/>.</returns>
     /// <exception cref="ArgumentException"><paramref name="style"/> is not a valid combination of the <see cref="NumberStyles"/> enumeration.</exception>
     public delegate bool NumberStylesTryParseFunc<T>(string s, NumberStyles style,
-        IFormatProvider formatProvider, out T result);
+        IFormatProvider? formatProvider, out T result);
 }

--- a/src/THNETII.TypeConverter/PrimitiveNumberStringConverter.cs
+++ b/src/THNETII.TypeConverter/PrimitiveNumberStringConverter.cs
@@ -22,7 +22,7 @@ namespace THNETII.TypeConverter
         /// formatting information for conversion. Omit or specify <see langword="null"/>
         /// to use the <see cref="NumberFormatInfo"/> for the current culture.
         /// </param>
-        public PrimitiveNumberStringConverter(IFormatProvider formatProvider = default)
+        public PrimitiveNumberStringConverter(IFormatProvider? formatProvider = default)
         {
             Int8 = new NumberStringConverter<sbyte>(sbyte.Parse, sbyte.TryParse, formatProvider);
             UInt8 = new NumberStringConverter<byte>(byte.Parse, byte.TryParse, formatProvider);

--- a/src/THNETII.TypeConverter/THNETII.TypeConverter.csproj
+++ b/src/THNETII.TypeConverter/THNETII.TypeConverter.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/THNETII.TypeConverter/THNETII.TypeConverter.csproj
+++ b/src/THNETII.TypeConverter/THNETII.TypeConverter.csproj
@@ -2,8 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>TH-NETII .NET Common library extension for type conversion</Description>
   </PropertyGroup>

--- a/test/THNETII.Common.Test/Common/Linq.Test/LinqExtensionsTest.cs
+++ b/test/THNETII.Common.Test/Common/Linq.Test/LinqExtensionsTest.cs
@@ -94,7 +94,8 @@ namespace THNETII.Common.Linq.Test
         public void FirstOrDefaultIgnoresFactoryIfNonEmpty()
         {
             var test = GetMoreThan5ButLessThan100();
-            T ignoredFactory() => throw new InvalidOperationException("The factory should never be invoked");
+
+            static T ignoredFactory() => throw new InvalidOperationException("The factory should never be invoked");
             Assert.Equal(PrimitiveFirst(test), FirstOrDefault(test, ignoredFactory));
         }
         #endregion
@@ -156,7 +157,8 @@ namespace THNETII.Common.Linq.Test
         public void LastOrDefaultIgnoresFactoryIfNonEmpty()
         {
             var test = GetMoreThan5ButLessThan100();
-            T ignoredFactory() => throw new InvalidOperationException("The factory should never be invoked");
+
+            static T ignoredFactory() => throw new InvalidOperationException("The factory should never be invoked");
             Assert.Equal(PrimitiveLast(test), LastOrDefault(test, ignoredFactory));
         }
         #endregion
@@ -255,7 +257,8 @@ namespace THNETII.Common.Linq.Test
         {
             const int index = 5;
             var test = GetMoreThan5ButLessThan100();
-            T ignoredFactory() => throw new InvalidOperationException("The factory should never be invoked");
+
+            static T ignoredFactory() => throw new InvalidOperationException("The factory should never be invoked");
             Assert.Equal(PrimitiveElementAt(test, index), ElementAtOrDefault(test, index, ignoredFactory));
         }
 

--- a/test/THNETII.Common.Test/Common/Linq.Test/LinqExtensionsTest.cs
+++ b/test/THNETII.Common.Test/Common/Linq.Test/LinqExtensionsTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+
 using Xunit;
 
 namespace THNETII.Common.Linq.Test
@@ -39,7 +40,7 @@ namespace THNETII.Common.Linq.Test
         #region First
         [SkippableFact]
         public void FirstOfNullThrows() =>
-            Assert.Throws<ArgumentNullException>(() => First(null));
+            Assert.Throws<ArgumentNullException>(() => First(null!));
 
         [SkippableFact]
         public void FirstOfEmptyThrows() =>
@@ -54,11 +55,11 @@ namespace THNETII.Common.Linq.Test
 
         [SkippableFact]
         public void FirstOrDefaultOfNullThrows() =>
-            Assert.Throws<ArgumentNullException>(() => FirstOrDefault(null));
+            Assert.Throws<ArgumentNullException>(() => FirstOrDefault(null!));
 
         [SkippableFact]
         public void FirstOrDefaultOfEmptyReturnsDefaultT() =>
-            Assert.Equal(default, FirstOrDefault(GetEmpty()));
+            Assert.Equal(default!, FirstOrDefault(GetEmpty()));
 
         [SkippableFact]
         public void FirstOrDefaultOfEmptyReturnsArgument()
@@ -101,7 +102,7 @@ namespace THNETII.Common.Linq.Test
         #region Last
         [SkippableFact]
         public void LastOfNullThrows() =>
-            Assert.Throws<ArgumentNullException>(() => Last(null));
+            Assert.Throws<ArgumentNullException>(() => Last(null!));
 
         [SkippableFact]
         public void LastOfEmptyThrows() =>
@@ -116,11 +117,11 @@ namespace THNETII.Common.Linq.Test
 
         [SkippableFact]
         public void LastOrDefaultOfNullThrows() =>
-            Assert.Throws<ArgumentNullException>(() => LastOrDefault(null));
+            Assert.Throws<ArgumentNullException>(() => LastOrDefault(null!));
 
         [SkippableFact]
         public void LastOrDefaultOfEmptyReturnsDefaultT() =>
-            Assert.Equal(default, LastOrDefault(GetEmpty()));
+            Assert.Equal(default!, LastOrDefault(GetEmpty()));
 
         [SkippableFact]
         public void LastOrDefaultOfEmptyReturnsArgument()
@@ -164,7 +165,7 @@ namespace THNETII.Common.Linq.Test
         [SkippableFact]
         public void ElementAtOfNullThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => ElementAt(null, default));
+            Assert.Throws<ArgumentNullException>(() => ElementAt(null!, default));
         }
 
         [SkippableFact]
@@ -181,11 +182,11 @@ namespace THNETII.Common.Linq.Test
 
         [SkippableFact]
         public void ElementAtOrDefaultOfNullThrows() =>
-            Assert.Throws<ArgumentNullException>(() => ElementAtOrDefault(null, default));
+            Assert.Throws<ArgumentNullException>(() => ElementAtOrDefault(null!, default));
 
         [SkippableFact]
         public void ElementAtOrDefaultOfEmptyReturnsDefaultT() =>
-            Assert.Equal(default, ElementAtOrDefault(GetEmpty(), default));
+            Assert.Equal(default!, ElementAtOrDefault(GetEmpty(), default));
 
         [SkippableFact]
         public void ElementAtOrDefaultOfEmptyReturnsArgument()
@@ -220,7 +221,7 @@ namespace THNETII.Common.Linq.Test
         public void ElementAtOrDefaultWithNegativeReturnsDefault()
         {
             var test = GetMoreThan5ButLessThan100();
-            T expected = default;
+            T expected = default!;
             Assert.Equal(expected, ElementAtOrDefault(test, -1));
         }
 
@@ -271,7 +272,7 @@ namespace THNETII.Common.Linq.Test
         {
             const int index = 100;
             var test = GetMoreThan5ButLessThan100();
-            Assert.Equal(default, ElementAtOrDefault(test, index));
+            Assert.Equal(default!, ElementAtOrDefault(test, index));
         }
 
         [SkippableFact]

--- a/test/THNETII.Common.Test/Common/Test/ArgumentExtensionsTest.cs
+++ b/test/THNETII.Common.Test/Common/Test/ArgumentExtensionsTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Xunit;
 
 namespace THNETII.Common.Test
@@ -19,21 +20,21 @@ namespace THNETII.Common.Test
         [Fact]
         public void ThrowIfNullThrowsArgumentNullExceptionIfArgumentNull()
         {
-            object obj = null;
+            object obj = null!;
             Assert.Throws<ArgumentNullException>(nameof(obj), () => obj.ThrowIfNull(nameof(obj)));
         }
 
         [Fact]
         public void ThrowIfNullAcceptsNullArgumentName()
         {
-            object obj = null;
-            Assert.Throws<ArgumentNullException>(() => obj.ThrowIfNull(null));
+            object obj = null!;
+            Assert.Throws<ArgumentNullException>(() => obj.ThrowIfNull(null!));
         }
 
         [Fact]
         public void ThrowIfNullAcceptsEmptyArgumentName()
         {
-            object obj = null;
+            object obj = null!;
             Assert.Throws<ArgumentNullException>(() => obj.ThrowIfNull(string.Empty));
         }
 
@@ -51,7 +52,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void ThrowIfNullOrEmptyThrowsArgumentNullExceptionIfArgumentNullString()
         {
-            string @string = null;
+            string? @string = null;
             Assert.Throws<ArgumentNullException>(nameof(@string), () => @string.ThrowIfNullOrEmpty(nameof(@string)));
         }
 
@@ -65,14 +66,14 @@ namespace THNETII.Common.Test
         [Fact]
         public void ThrowIfNullOrEmptyStringAcceptsNullArgumentName()
         {
-            string @string = null;
-            Assert.Throws<ArgumentNullException>(() => @string.ThrowIfNullOrEmpty(null));
+            string? @string = null;
+            Assert.Throws<ArgumentNullException>(() => @string.ThrowIfNullOrEmpty(null!));
         }
 
         [Fact]
         public void ThrowIfNullOrEmptyStringAcceptsEmptyArgumentName()
         {
-            string @string = null;
+            string? @string = null;
             Assert.Throws<ArgumentNullException>(() => @string.ThrowIfNullOrEmpty(string.Empty));
         }
 
@@ -90,7 +91,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void ThrowIfNullOrEmptyThrowsArgumentNullExceptionIfArgumentNullArray()
         {
-            int[] array = null;
+            int[]? array = null;
             Assert.Throws<ArgumentNullException>(nameof(array), () => array.ThrowIfNullOrEmpty(nameof(array)));
         }
 
@@ -104,14 +105,14 @@ namespace THNETII.Common.Test
         [Fact]
         public void ThrowIfNullOrEmptyArrayAcceptsNullArgumentName()
         {
-            int[] array = null;
-            Assert.Throws<ArgumentNullException>(() => array.ThrowIfNullOrEmpty(null));
+            int[]? array = null;
+            Assert.Throws<ArgumentNullException>(() => array.ThrowIfNullOrEmpty(null!));
         }
 
         [Fact]
         public void ThrowIfNullOrEmptyArrayAcceptsEmptyArgumentName()
         {
-            int[] array = null;
+            int[]? array = null;
             Assert.Throws<ArgumentNullException>(() => array.ThrowIfNullOrEmpty(string.Empty));
         }
 
@@ -123,13 +124,13 @@ namespace THNETII.Common.Test
         public void ThrowIfNullOrEmptyReturnsSameReferenceIfArgumentNotNullOrEmptyEnumerable()
         {
             IEnumerable<int> enumerable = Enumerable.Range(0, 10);
-            Assert.Equal(enumerable, enumerable.ThrowIfNullOrEmpty(nameof(enumerable)));
+            Assert.Same(enumerable, enumerable.ThrowIfNullOrEmpty(nameof(enumerable)));
         }
 
         [Fact]
         public void ThrowIfNullOrEmptyThrowsArgumentNullExceptionIfArgumentNullEnumerable()
         {
-            IEnumerable<int> enumerable = null;
+            IEnumerable<int>? enumerable = null;
             Assert.Throws<ArgumentNullException>(nameof(enumerable), () => enumerable.ThrowIfNullOrEmpty(nameof(enumerable)));
         }
 
@@ -143,14 +144,14 @@ namespace THNETII.Common.Test
         [Fact]
         public void ThrowIfNullOrEmptyEnumerableAcceptsNullArgumentName()
         {
-            IEnumerable<int> enumerable = null;
-            Assert.Throws<ArgumentNullException>(() => enumerable.ThrowIfNullOrEmpty(null));
+            IEnumerable<int>? enumerable = null;
+            Assert.Throws<ArgumentNullException>(() => enumerable.ThrowIfNullOrEmpty(null!));
         }
 
         [Fact]
         public void ThrowIfNullOrEmptyEnumerableAcceptsEmptyArgumentName()
         {
-            IEnumerable<int> enumerable = null;
+            IEnumerable<int>? enumerable = null;
             Assert.Throws<ArgumentNullException>(() => enumerable.ThrowIfNullOrEmpty(string.Empty));
         }
 
@@ -168,7 +169,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void ThrowIfNullOrWhiteSpaceThrowsArgumentNullExceptionIfArgumentNull()
         {
-            string str = null;
+            string? str = null;
             Assert.Throws<ArgumentNullException>(() => str.ThrowIfNullOrWhiteSpace(nameof(str)));
         }
 
@@ -186,14 +187,14 @@ namespace THNETII.Common.Test
         [Fact]
         public void ThrowIfNullOrWhiteSpaceAcceptsNullArgumentName()
         {
-            string str = null;
-            Assert.Throws<ArgumentNullException>(() => str.ThrowIfNullOrWhiteSpace(null));
+            string? str = null;
+            Assert.Throws<ArgumentNullException>(() => str.ThrowIfNullOrWhiteSpace(null!));
         }
 
         [Fact]
         public void ThrowIfNullOrWhiteSpaceAcceptsEmptyArgumentName()
         {
-            string str = null;
+            string? str = null;
             Assert.Throws<ArgumentNullException>(() => str.ThrowIfNullOrWhiteSpace(string.Empty));
         }
 

--- a/test/THNETII.Common.Test/Common/Test/ArgumentExtensionsTest.cs
+++ b/test/THNETII.Common.Test/Common/Test/ArgumentExtensionsTest.cs
@@ -124,7 +124,7 @@ namespace THNETII.Common.Test
         public void ThrowIfNullOrEmptyReturnsSameReferenceIfArgumentNotNullOrEmptyEnumerable()
         {
             IEnumerable<int> enumerable = Enumerable.Range(0, 10);
-            Assert.Same(enumerable, enumerable.ThrowIfNullOrEmpty(nameof(enumerable)));
+            Assert.Equal(enumerable, enumerable.ThrowIfNullOrEmpty(nameof(enumerable)));
         }
 
         [Fact]

--- a/test/THNETII.Common.Test/Common/Test/CommonExtensionsTest.cs
+++ b/test/THNETII.Common.Test/Common/Test/CommonExtensionsTest.cs
@@ -32,16 +32,16 @@ namespace THNETII.Common.Test
         public void NotNullAcceptsOtherwiseNull()
         {
             var instance = new object();
-            Assert.Same(instance, instance.NotNull(otherwise: null));
+            Assert.Same(instance, instance.NotNull(otherwise: null!));
         }
 
         [Fact]
         public void NotNullReturnsOtherwiseIfNull()
         {
-            object instance = null;
+            object instance = null!;
             var magic = new object();
 
-            Assert.Same(magic, instance.NotNull(magic));
+            Assert.Same(magic, instance.NotNull(otherwise: magic));
         }
 
         #endregion
@@ -61,7 +61,7 @@ namespace THNETII.Common.Test
         {
             var instance = new object();
 
-            Assert.Same(instance, instance.NotNull(otherwiseFactory: null));
+            Assert.Same(instance, instance.NotNull(otherwiseFactory: null!));
         }
 
         [Fact]
@@ -82,9 +82,9 @@ namespace THNETII.Common.Test
         [Fact]
         public void NotNullFactoryReturnsFactoryValueIfNull()
         {
-            object instance = null;
+            object? instance = null;
             bool invoked = false;
-            object expected = default;
+            object? expected = default;
             object otherwiseFactory()
             {
                 invoked = true;
@@ -112,7 +112,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void NotNullOrEmptyReturnsOtherwiseIfNullString()
         {
-            string str = null;
+            string? str = null;
             string otherwise = nameof(str);
 
             Assert.Same(otherwise, str.NotNullOrEmpty(otherwise));
@@ -152,7 +152,7 @@ namespace THNETII.Common.Test
         {
             string str = nameof(NotNullOrEmptyFactoryAcceptsNullFactoryIfNotNullString);
 
-            Assert.Same(str, str.NotNullOrEmpty(otherwiseFactory: null));
+            Assert.Same(str, str.NotNullOrEmpty(otherwiseFactory: null!));
         }
 
         [Fact]
@@ -173,9 +173,9 @@ namespace THNETII.Common.Test
         [Fact]
         public void NotNullOrEmptyFactoryReturnsFactoryValueIfNullString()
         {
-            string str = null;
+            string? str = null;
             bool invoked = false;
-            string expected = default;
+            string? expected = default;
             string otherwiseFactory()
             {
                 invoked = true;
@@ -203,7 +203,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void NotNullOrEmptyReturnsOtherwiseIfNullArray()
         {
-            int[] array = null;
+            int[]? array = null;
             int[] otherwise = Enumerable.Range(0, 10).ToArray();
 
             Assert.Same(otherwise, array.NotNullOrEmpty(otherwise));
@@ -223,7 +223,7 @@ namespace THNETII.Common.Test
         {
             int[] array = Enumerable.Range(0, 10).ToArray();
 
-            _ = array.NotNullOrEmpty(otherwise: null);
+            _ = array.NotNullOrEmpty(otherwise: null!);
         }
 
         #endregion
@@ -243,7 +243,7 @@ namespace THNETII.Common.Test
         {
             int[] array = Enumerable.Range(0, 10).ToArray();
 
-            Assert.Same(array, array.NotNullOrEmpty(otherwiseFactory: null));
+            Assert.Same(array, array.NotNullOrEmpty(otherwiseFactory: null!));
         }
 
         [Fact]
@@ -264,9 +264,9 @@ namespace THNETII.Common.Test
         [Fact]
         public void NotNullOrEmptyFactoryReturnsFactoryValueIfNullArray()
         {
-            int[] array = null;
+            int[]? array = null;
             bool invoked = false;
-            int[] expected = default;
+            int[]? expected = default;
             int[] otherwiseFactory()
             {
                 invoked = true;
@@ -314,7 +314,7 @@ namespace THNETII.Common.Test
         {
             IEnumerable<int> enumerable = Enumerable.Range(0, 10);
 
-            _ = enumerable.NotNullOrEmpty(otherwise: null);
+            _ = enumerable.NotNullOrEmpty(otherwise: null!);
         }
 
         #endregion
@@ -355,9 +355,9 @@ namespace THNETII.Common.Test
         [Fact]
         public void NotNullOrEmptyFactoryReturnsFactoryValueIfNullEnumerable()
         {
-            IEnumerable<int> enumerable = null;
+            IEnumerable<int>? enumerable = null;
             bool invoked = false;
-            IEnumerable<int> expected = default;
+            IEnumerable<int>? expected = default;
             IEnumerable<int> otherwiseFactory()
             {
                 invoked = true;
@@ -385,7 +385,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void NotNullOrWhiteSpaceReturnsOtherwiseIfNullString()
         {
-            string str = null;
+            string? str = null;
             string otherwise = nameof(str);
 
             Assert.Same(otherwise, str.NotNullOrWhiteSpace(otherwise));
@@ -413,7 +413,7 @@ namespace THNETII.Common.Test
         {
             string str = nameof(NotNullOrWhiteSpaceAcceptsOtherwiseNullString);
 
-            _ = str.NotNullOrWhiteSpace(otherwise: null);
+            _ = str.NotNullOrWhiteSpace(otherwise: null!);
         }
 
         #endregion
@@ -433,7 +433,7 @@ namespace THNETII.Common.Test
         {
             string str = nameof(NotNullOrWhiteSpaceFactoryAcceptsNullFactoryIfNotNullString);
 
-            Assert.Same(str, str.NotNullOrWhiteSpace(otherwiseFactory: null));
+            Assert.Same(str, str.NotNullOrWhiteSpace(otherwiseFactory: null!));
         }
 
         [Fact]
@@ -454,9 +454,9 @@ namespace THNETII.Common.Test
         [Fact]
         public void NotNullOrWhiteSpaceFactoryReturnsFactoryValueIfNullString()
         {
-            string str = null;
+            string? str = null;
             bool invoked = false;
-            string expected = default;
+            string? expected = default;
             string otherwiseFactory()
             {
                 invoked = true;
@@ -486,7 +486,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void TryNotNullReturnsFalseIfNull()
         {
-            object instance = null;
+            object? instance = null;
 
             Assert.False(instance.TryNotNull(out var _));
         }
@@ -508,7 +508,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void TryNotNullOrEmptyReturnsFalseIfNullString()
         {
-            string str = null;
+            string? str = null;
 
             Assert.False(str.TryNotNullOrEmpty(out var _));
         }
@@ -538,7 +538,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void TryNotNullOrEmptyReturnsFalseIfNullArray()
         {
-            int[] array = null;
+            int[]? array = null;
 
             Assert.False(array.TryNotNullOrEmpty(out var _));
         }
@@ -568,7 +568,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void TryNotNullOrEmptyReturnsFalseIfNullEnumerable()
         {
-            IEnumerable<int> enumerable = null;
+            IEnumerable<int>? enumerable = null;
 
             Assert.False(enumerable.TryNotNullOrEmpty(out var _));
         }
@@ -598,7 +598,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void TryNotNullOrWhiteSpaceReturnsFalseIfNullString()
         {
-            string str = null;
+            string? str = null;
 
             Assert.False(str.TryNotNullOrWhiteSpace(out var _));
         }
@@ -624,7 +624,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void ZeroLengthIfNullReturnsEmptyIfNull()
         {
-            int[] array = null;
+            int[]? array = null;
 
             Assert.Empty(array.ZeroLengthIfNull());
         }
@@ -644,7 +644,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void EmptyIfNullReturnsEmptyIfNull()
         {
-            IEnumerable<int> enumerable = null;
+            IEnumerable<int>? enumerable = null;
 
             Assert.Empty(enumerable.EmptyIfNull());
         }

--- a/test/THNETII.Common.Test/Common/Test/CommonExtensionsTest.cs
+++ b/test/THNETII.Common.Test/Common/Test/CommonExtensionsTest.cs
@@ -294,7 +294,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void NotNullOrEmptyReturnsOtherwiseIfNullEnumerable()
         {
-            IEnumerable<int> enumerable = null;
+            IEnumerable<int>? enumerable = null;
             IEnumerable<int> otherwise = Enumerable.Empty<int>();
 
             Assert.Same(otherwise, enumerable.NotNullOrEmpty(otherwise));
@@ -334,7 +334,7 @@ namespace THNETII.Common.Test
         {
             IEnumerable<int> enumerable = Enumerable.Range(0, 10);
 
-            Assert.Equal(enumerable, enumerable.NotNullOrEmpty(otherwiseFactory: null));
+            Assert.Equal(enumerable, enumerable.NotNullOrEmpty(otherwiseFactory: null!));
         }
 
         [Fact]

--- a/test/THNETII.Common.Test/Common/Test/ConversionTupleTest.cs
+++ b/test/THNETII.Common.Test/Common/Test/ConversionTupleTest.cs
@@ -9,7 +9,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void NullConverterThrowsArgumentException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ConversionTuple<int, string>(rawConvert: null));
+            Assert.Throws<ArgumentNullException>(() => new ConversionTuple<int, string>(rawConvert: null!));
         }
 
         [Fact]
@@ -38,17 +38,6 @@ namespace THNETII.Common.Test
 
         [Fact]
         [SuppressMessage("Microsoft.Design", "CA1305", Justification = "int.ToString() return value not relevant for test case.")]
-        public void InstanceEqualityWithBothNull()
-        {
-            ConversionTuple<int, string> l = null, r = null;
-
-            Assert.Equal(l, r);
-            Assert.True(l == r);
-            Assert.False(l != r);
-        }
-
-        [Fact]
-        [SuppressMessage("Microsoft.Design", "CA1305", Justification = "int.ToString() return value not relevant for test case.")]
         public void InstanceInequality()
         {
             const int testRawValueLeft = 42;
@@ -59,23 +48,6 @@ namespace THNETII.Common.Test
             var r = new ConversionTuple<int, string>(intToString);
 
             (l.RawValue, r.RawValue) = (testRawValueLeft, testRawValueRight);
-
-            Assert.NotEqual(l, r);
-            Assert.True(l != r);
-            Assert.False(l == r);
-        }
-
-        [Fact]
-        [SuppressMessage("Microsoft.Design", "CA1305", Justification = "int.ToString() return value not relevant for test case.")]
-        public void InstanceInequalityWithOneNull()
-        {
-            const int testRawValue = 42;
-
-            string intToString(int i) => i.ToString();
-            var l = new ConversionTuple<int, string>(intToString);
-            ConversionTuple<int, string> r = null;
-
-            l.RawValue = testRawValue;
 
             Assert.NotEqual(l, r);
             Assert.True(l != r);

--- a/test/THNETII.Common.Test/Common/Test/ConversionTupleTest.cs
+++ b/test/THNETII.Common.Test/Common/Test/ConversionTupleTest.cs
@@ -25,7 +25,7 @@ namespace THNETII.Common.Test
         {
             const int testRawValue = 42;
 
-            string intToString(int i) => i.ToString();
+            static string intToString(int i) => i.ToString();
             var l = new ConversionTuple<int, string>(intToString);
             var r = new ConversionTuple<int, string>(intToString);
 
@@ -43,7 +43,7 @@ namespace THNETII.Common.Test
             const int testRawValueLeft = 42;
             const int testRawValueRight = ~testRawValueLeft;
 
-            string intToString(int i) => i.ToString();
+            static string intToString(int i) => i.ToString();
             var l = new ConversionTuple<int, string>(intToString);
             var r = new ConversionTuple<int, string>(intToString);
 

--- a/test/THNETII.Common.Test/Common/Test/MaybeTest.cs
+++ b/test/THNETII.Common.Test/Common/Test/MaybeTest.cs
@@ -26,7 +26,7 @@ namespace THNETII.Common.Test
         [Fact]
         public static void NewWithNullArgumentHasValue()
         {
-            object value = null;
+            object? value = null;
             var maybe = Maybe.Create(value);
             Assert.True(maybe.HasValue);
             Assert.Null(maybe.Value);

--- a/test/THNETII.Common.Test/Common/Test/MaybeTest.cs
+++ b/test/THNETII.Common.Test/Common/Test/MaybeTest.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Linq;
+
 using Xunit;
 
 namespace THNETII.Common.Test

--- a/test/THNETII.Common.Test/Common/Test/StringCommonExtensionsTest.cs
+++ b/test/THNETII.Common.Test/Common/Test/StringCommonExtensionsTest.cs
@@ -11,15 +11,15 @@ namespace THNETII.Common.Test
         [Fact]
         public void ContainsThrowsWithNullSource()
         {
-            const string test = null;
-            Assert.Throws<ArgumentNullException>(() => StringCommonExtensions.Contains(test, "test", default));
+            const string? test = null;
+            Assert.Throws<ArgumentNullException>(() => StringCommonExtensions.Contains(test!, "test", default));
         }
 
         [Fact]
         public void ContainsThrowsWithNullValue()
         {
             const string test = "test";
-            Assert.Throws<ArgumentNullException>(() => StringCommonExtensions.Contains(test, null, default));
+            Assert.Throws<ArgumentNullException>(() => StringCommonExtensions.Contains(test, null!, default));
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace THNETII.Common.Test
         [Fact]
         public void EnumerateLinesOfNullThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => ((string)null).EnumerateLines());
+            Assert.Throws<ArgumentNullException>(() => ((string)null!).EnumerateLines());
         }
 
         [Fact]
@@ -59,15 +59,15 @@ namespace THNETII.Common.Test
         [Fact]
         public void MultiReplaceOnNullThrows()
         {
-            const string nullString = null;
-            Assert.Throws<ArgumentNullException>("s", () => nullString.Replace(mappings: null));
+            const string? nullString = null;
+            Assert.Throws<ArgumentNullException>("s", () => nullString!.Replace(mappings: null!));
         }
 
         [Fact]
         public void MultiReplaceWithNullMappingsThrows()
         {
             const string test = nameof(MultiReplaceWithNullMappingsThrows);
-            Assert.Throws<ArgumentNullException>("mappings", () => test.Replace(mappings: null));
+            Assert.Throws<ArgumentNullException>("mappings", () => test.Replace(mappings: null!));
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace THNETII.Common.Test
             const string test = nameof(MultiReplaceWithNullOldValueThrows);
             Assert.Throws<ArgumentNullException>(
                 FormattableString.Invariant($"mappings[{0}].oldValue"),
-                () => test.Replace(new[] { ((string)null, string.Empty) })
+                () => test.Replace(new[] { ((string)null!, string.Empty) })
                 );
         }
 
@@ -86,7 +86,7 @@ namespace THNETII.Common.Test
             const string test = nameof(MultiReplaceWithNullNewValueThrows);
             Assert.Throws<ArgumentNullException>(
                 FormattableString.Invariant($"mappings[{0}].newValue"),
-                () => test.Replace(new[] { (string.Empty, (string)null) })
+                () => test.Replace(new[] { (string.Empty, (string)null!) })
                 );
         }
 

--- a/test/THNETII.Common.Test/Common/Test/StringEditDistanceExtensionsTest.cs
+++ b/test/THNETII.Common.Test/Common/Test/StringEditDistanceExtensionsTest.cs
@@ -17,8 +17,9 @@ namespace THNETII.Common.Test
         [Fact]
         public void EditDistanceAcceptsNullFirstArgument()
         {
+            const string? first = null;
             const string other = "abc";
-            Assert.Equal(other.Length, StringEditDistanceExtensions.EditDistance(null, other));
+            Assert.Equal(other.Length, first.EditDistance(other));
         }
 
         [Fact]

--- a/test/THNETII.Common.Test/THNETII.Common.Test.csproj
+++ b/test/THNETII.Common.Test/THNETII.Common.Test.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/THNETII.Common.Test/THNETII.Common.Test.csproj
+++ b/test/THNETII.Common.Test/THNETII.Common.Test.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/THNETII.DependencyInjection.Nesting.Test/ConfigurationNestingTest.cs
+++ b/test/THNETII.DependencyInjection.Nesting.Test/ConfigurationNestingTest.cs
@@ -38,7 +38,7 @@ namespace THNETII.DependencyInjection.Nesting.Test
                 .AddInMemoryCollection(configDict)
                 .Build();
 
-            void configureTestService(INestedServiceCollection services)
+            static void configureTestService(INestedServiceCollection services)
                 => services.AddSingleton<TestService>();
 
             var serviceProvider = new ServiceCollection()


### PR DESCRIPTION
Older version of .NET can still use C# 8 and enable nullability checks, but the Nullability attributes are not usable, since they are shipped with newer versions of the `System.Runtime` component (see [.NET API Catalog](https://apisof.net/catalog/System.Diagnostics.CodeAnalysis.MaybeNullAttribute)). For that reason include package [Nullable](https://www.nuget.org/packages/Nullable/) if
* TFM < .NET Standard 2.1
* TFM < .NET Core App 3.0
* TFM is any .NET Framework