### PR TITLE
Add System.CommandLine dependency to THNETII.CommandLine.Hosting

### DIFF
--- a/src/THNETII.CommandLine.Hosting/DefaultCommandLine.cs
+++ b/src/THNETII.CommandLine.Hosting/DefaultCommandLine.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Hosting;
 using System;
 using System.CommandLine.Builder;
 using System.CommandLine.Hosting;
-using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
 using System.Threading.Tasks;
 
 namespace THNETII.CommandLine.Hosting

--- a/src/THNETII.CommandLine.Hosting/THNETII.CommandLine.Hosting.csproj
+++ b/src/THNETII.CommandLine.Hosting/THNETII.CommandLine.Hosting.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.4" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20253.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.19405.1" />
   </ItemGroup>
 


### PR DESCRIPTION
The transitive dependency of `System.CommandLine.Hosting` is out of date.